### PR TITLE
Updated the Doctrine connection adapters to include the existing project...

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ and inside your test you could use those variables to better identify the curren
 
 ``` php
 echo getenv('ENV_TEST_CHANNEL');          // The number of the current channel that is using the current test eg.2
-echo getenv('ENV_TEST_CHANNEL_READABLE'); // Name for the database, is a readable name eg. test_2
+echo getenv('ENV_TEST_CHANNEL_READABLE'); // Name used to make the database name unique, is a readable name eg. test_2
 echo getenv('ENV_TEST_CHANNELS_NUMBER');  // Max channel number on a system (the core number) eg. 4
 echo getenv('ENV_TEST_ARGUMENT');         // The current running test eg. tests/UserFunctionalTest.php
 echo getenv('ENV_TEST_INC_NUMBER');       // Unique number of the current test eg. 32
@@ -109,7 +109,7 @@ find tests/ -name "*Test.php" | ./bin/fastest -b"app/console doc:sch:create -e t
 If you want to parallel functional tests, and if you have a machine with 4 CPUs, the best think you could do is create a db foreach parallel process,
 `fastest` gives you the opportunity to work easily with Symfony.
 
-Modifying the config_test config file in Symfony, each functional test will look for a database called `test_x` automatically (x is from 1 to CPUs number).
+Modifying the config_test config file in Symfony, each functional test will look for a database called `<database_name>_test_x` automatically (x is from 1 to CPUs number).
 
 ### Doctrine DBAL
 

--- a/adapters/Doctrine/DBAL/ConnectionFactory.php
+++ b/adapters/Doctrine/DBAL/ConnectionFactory.php
@@ -32,7 +32,7 @@ class ConnectionFactory extends BaseConnectionFactory
     private function getDbNameFromEnv($dbName)
     {
         if ($this->issetDbNameEnvValue()) {
-            return $this->getDbNameEnvValue();
+            return $dbName.'_'.$this->getDbNameEnvValue();
         }
 
         return $dbName;

--- a/adapters/Doctrine/MongoDB/Connection.php
+++ b/adapters/Doctrine/MongoDB/Connection.php
@@ -17,7 +17,7 @@ class Connection extends BaseConnection
     private function getDbNameFromEnv($dbName)
     {
         if ($this->issetDbNameEnvValue()) {
-            return $this->getDbNameEnvValue();
+            return $dbName.'_'.$this->getDbNameEnvValue();
         }
 
         return $dbName;


### PR DESCRIPTION
... database name when retrieving a unique database name from the environment

This is to allow multiple projects using the same database server to run their tests concurrently without overwriting each others data, such as on a Jenkins Continuous Integration server.
