### PR TITLE
Add --no-errors-summary option

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ If you want to use it with phpunit you may want to install phpunit/phpunit as de
 
 ```
 Usage:
- fastest [-p|--process="..."] [-b|--before="..."] [-x|--xml="..."] [-o|--preserve-order] [execute]
+ fastest [-p|--process="..."] [-b|--before="..."] [-x|--xml="..."] [-o|--preserve-order] [--no-errors-summary] [execute]
 
 Arguments:
  execute               Optional command to execute.
@@ -229,6 +229,7 @@ Options:
  --before (-b)         Execute a process before consuming the queue, it executes this command once per process, useful for init schema and load fixtures.
  --xml (-x)            Read input from a phpunit xml file from the '<testsuites>' collection. Note: it is not used for consuming.
  --preserve-order (-o) Queue is randomized by default, with this option the queue is read preserving the order.
+ --no-errors-summary   Do not display all errors after the test run. Useful with --vv because it already displays errors immediately after they happen.
  --help (-h)           Display this help message.
  --quiet (-q)          Do not output any message.
  --verbose (-v|vv|vvv) Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

--- a/src/UI/ProgressBarRenderer.php
+++ b/src/UI/ProgressBarRenderer.php
@@ -16,10 +16,19 @@ class ProgressBarRenderer implements RendererInterface
     private $output;
     private $preProcesses;
     private $messagesInTheQueue;
+    private $errorsSummary;
 
-    public function __construct($messageInTheQueue, OutputInterface $output, $helper, $preProcesses = 0)
+    /**
+     * @param $messageInTheQueue
+     * @param bool $errorsSummary Whether to display errors summary in the footer
+     * @param OutputInterface $output
+     * @param $helper
+     * @param int $preProcesses
+     */
+    public function __construct($messageInTheQueue, $errorsSummary, OutputInterface $output, $helper, $preProcesses = 0)
     {
         $this->messagesInTheQueue = $messageInTheQueue;
+        $this->errorsSummary = $errorsSummary;
         $this->output = $output;
         $this->helper = $helper;
         $this->preProcesses = (int) $preProcesses;
@@ -75,7 +84,9 @@ class ProgressBarRenderer implements RendererInterface
         $this->renderBody($queue, $processes);
         $this->bar->finish();
         $this->output->writeln('');
-        $this->output->writeln($processes->getErrorOutput());
+        if ($this->errorsSummary) {
+            $this->output->writeln($processes->getErrorOutput());
+        }
 
         $out = "    <info>✔</info> You are great!";
         if (!$processes->isSuccessful()) {

--- a/src/UI/VerboseRenderer.php
+++ b/src/UI/VerboseRenderer.php
@@ -11,10 +11,17 @@ class VerboseRenderer implements RendererInterface
     private $messageInTheQueue;
     private $lastIndex;
     private $output;
+    private $errorsSummary;
 
-    public function __construct($messageInTheQueue, OutputInterface $output)
+    /**
+     * @param $messageInTheQueue
+     * @param bool $errorsSummary Whether to display errors summary in the footer
+     * @param OutputInterface $output
+     */
+    public function __construct($messageInTheQueue, $errorsSummary, OutputInterface $output)
     {
         $this->messageInTheQueue = $messageInTheQueue;
+        $this->errorsSummary = $errorsSummary;
         $this->output = $output;
         $this->lastIndex = 0;
     }
@@ -27,7 +34,9 @@ class VerboseRenderer implements RendererInterface
     {
         $this->renderBody($queue, $processes);
         $this->output->writeln('');
-        $this->output->writeln($processes->getErrorOutput());
+        if ($this->errorsSummary) {
+            $this->output->writeln($processes->getErrorOutput());
+        }
 
         $out = "    <info>✔</info> You are great!";
         if (!$processes->isSuccessful()) {


### PR DESCRIPTION
Use case for this is as follows:
We have a lot of functional tests that even with fastest run about ~10 minutes on our CI system. Sometimes developers will look at the log right away to see if the tests are passing and they should fix something, but sometimes they will only look when the build is already over. Using this option among with `-vv` would help us to both see failures in realtime and do not display errors twice in a final log.