### PR TITLE
Display time it took the process to run in Verbose mode

### DIFF
--- a/src/Command/ParallelCommand.php
+++ b/src/Command/ParallelCommand.php
@@ -134,12 +134,12 @@ class ParallelCommand extends Command
             $progressBar = new ProgressBarRenderer($queue->count(),$this->hasErrorSummary($input), $output, $this->getHelper('progress'), $processManager->getNumberOfProcessExecutedByTheBeforeCommand());
         }
 
-        $progressBar->renderHeader($queue, $processes);
+        $progressBar->renderHeader($queue);
 
         while ($processManager->assertNProcessRunning($queue, $processes)) {
             $progressBar->renderBody($queue, $processes);
         }
-        
+
         /**
          * @var Processes $processes
          */

--- a/src/Command/ParallelCommand.php
+++ b/src/Command/ParallelCommand.php
@@ -143,7 +143,9 @@ class ParallelCommand extends Command
         /**
          * @var Processes $processes
          */
-        $processes->wait();
+        $processes->wait(function() use ($progressBar, $queue, $processes) {
+            $progressBar->renderBody($queue, $processes);
+        });
         $progressBar->renderFooter($queue, $processes);
 
         return $processes;

--- a/src/Command/ParallelCommand.php
+++ b/src/Command/ParallelCommand.php
@@ -2,6 +2,8 @@
 
 namespace Liuggio\Fastest\Command;
 
+use Liuggio\Fastest\Process\Processes;
+use Liuggio\Fastest\Queue\QueueInterface;
 use Liuggio\Fastest\Queue\TestsQueue;
 use Liuggio\Fastest\UI\ProgressBarRenderer;
 use Liuggio\Fastest\UI\VerboseRenderer;
@@ -114,12 +116,15 @@ class ParallelCommand extends Command
 
     /**
      * @param InputInterface $input
-     * @param  OutputInterface $output
-     * @param $queue
-     * @param $processManager
+     * @param OutputInterface $output
+     * @param QueueInterface $queue
+     * @param ProcessesManager $processManager
      * @return array
      */
-    private function doExecute(InputInterface $input, OutputInterface $output, $queue, $processManager)
+    private function doExecute(InputInterface $input,
+                               OutputInterface $output,
+                               QueueInterface $queue,
+                               ProcessesManager $processManager)
     {
         $processes = null;
 
@@ -134,7 +139,10 @@ class ParallelCommand extends Command
         while ($processManager->assertNProcessRunning($queue, $processes)) {
             $progressBar->renderBody($queue, $processes);
         }
-
+        
+        /**
+         * @var Processes $processes
+         */
         $processes->wait();
         $progressBar->renderFooter($queue, $processes);
 

--- a/src/Process/Processes.php
+++ b/src/Process/Processes.php
@@ -113,17 +113,6 @@ class Processes
         return $this->processes[$index];
     }
 
-    public function isAnyStillRunning()
-    {
-        $noOneIsRunning = true;
-
-        foreach ($this->processes as $process) {
-            $noOneIsRunning = $noOneIsRunning && (null === $process || $process->isTerminated());
-        }
-
-        return !$noOneIsRunning;
-    }
-
     /**
      * @return int Number of processes still running
      */

--- a/src/Process/Report.php
+++ b/src/Process/Report.php
@@ -10,17 +10,31 @@ class Report
     private $time;
     private $isFirstOnThread;
 
-    public function __construct($suite, $isSuccess, $processorNumber, $errorBuffer, $isFirstOnThread)
+    /**
+     * @param string $suite
+     * @param boolean $isSuccess
+     * @param int $time
+     * @param int $processorNumber
+     * @param string|null $errorBuffer
+     * @param boolean $isFirstOnThread
+     */
+    public function __construct($suite, 
+                                $isSuccess,
+                                $time,
+                                $processorNumber,
+                                $errorBuffer,
+                                $isFirstOnThread)
     {
         $this->isSuccess = $isSuccess;
         $this->processorNumber = $processorNumber;
         $this->suite = $suite;
         $this->errorBuffer = $errorBuffer;
         $this->isFirstOnThread = $isFirstOnThread;
+        $this->time = $time;
     }
 
     /**
-     * @return mixed
+     * @return boolean
      */
     public function isSuccessful()
     {
@@ -28,7 +42,7 @@ class Report
     }
 
     /**
-     * @return mixed
+     * @return int
      */
     public function getProcessorNumber()
     {
@@ -36,7 +50,7 @@ class Report
     }
 
     /**
-     * @return mixed
+     * @return boolean
      */
     public function isFirstOnThread()
     {
@@ -44,7 +58,7 @@ class Report
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getSuite()
     {
@@ -52,7 +66,7 @@ class Report
     }
 
     /**
-     * @return mixed
+     * @return int Time in microseconds
      */
     public function getTime()
     {
@@ -60,7 +74,7 @@ class Report
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getErrorBuffer()
     {

--- a/src/UI/VerboseRenderer.php
+++ b/src/UI/VerboseRenderer.php
@@ -75,7 +75,12 @@ class VerboseRenderer implements RendererInterface
             }
 
             $remaining = sprintf('%d/%d', $this->lastIndex, $this->messageInTheQueue);
-            $this->output->writeln($processorN.$remaining."\t".$flag."\t".$report->getSuite().$err);
+            $time = round($report->getTime() * 1000) . ' ms';
+            // add a tab to add some space for longer strings so that the next column doesn't jump
+            if (strlen($time) < 8) {
+                $time .= "\t";
+            }
+            $this->output->writeln($processorN.$remaining."\t".$flag."\t".$time."\t".$report->getSuite().$err);
         }
         $this->lastIndex = $count;
 

--- a/tests/Process/ProcessesTest.php
+++ b/tests/Process/ProcessesTest.php
@@ -36,7 +36,15 @@ class ProcessesTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldWaitAllTheItems()
     {
-        $process = $this->mockProcessWithExpectation('wait');
+        $process = $this->getMockBuilder('\Symfony\Component\Process\Process')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $process
+            ->expects($this->exactly(5))
+            ->method('isTerminated')
+            ->willReturn(false)
+            ->willReturnOnConsecutiveCalls(false, false, false, true)
+        ;
 
         $processes = new Processes(array($process));
 
@@ -55,4 +63,3 @@ class ProcessesTest extends \PHPUnit_Framework_TestCase
         return $process;
     }
 }
- 


### PR DESCRIPTION
To achieve this I also had to rework waiting for the last processes, so now the progressbar rendering in the end of the queue is done when every process is terminated, not just once when they all are. This fixes a weird behaviour in verbose log that in the end of the queue there was always `$totalParallelProcesses` less log lines then total, even if just one process is running.