### PR TITLE
Clean up processes before waiting

### DIFF
--- a/src/Command/ParallelCommand.php
+++ b/src/Command/ParallelCommand.php
@@ -143,6 +143,7 @@ class ParallelCommand extends Command
         /**
          * @var Processes $processes
          */
+        $processes->cleanUP(); //it is not getting called with -p1 after the last process otherwise
         $processes->wait(function() use ($progressBar, $queue, $processes) {
             $progressBar->renderBody($queue, $processes);
         });


### PR DESCRIPTION
This fixes newly introduced bug where the last entry is not displayed in the verbose log when running with `-p1`