### PR TITLE
Change path instead of dbName for SQLite driver

### DIFF
--- a/adapters/Doctrine/DBAL/ConnectionFactory.php
+++ b/adapters/Doctrine/DBAL/ConnectionFactory.php
@@ -24,7 +24,13 @@ class ConnectionFactory extends BaseConnectionFactory
      */
     public function createConnection(array $params, Configuration $config = null, EventManager $eventManager = null, array $mappingTypes = array())
     {
-        $params['dbname'] = $this->getDbNameFromEnv($params['dbname']);
+        $dbName = $this->getDbNameFromEnv($params['dbname']);
+                
+        if ($params['driver'] === 'pdo_sqlite') {
+            $params['path'] = str_replace("__DBNAME__", $dbName, $params['path']);
+        } else {
+            $params['dbname'] = $dbName;
+        }
 
         return parent::createConnection($params, $config, $eventManager, $mappingTypes);
     }


### PR DESCRIPTION
SQLite does not have `dbname` parameter (in fact, SQLite databases do not have names - it's always one database per 1 file). So, if useing sqlite, you should

```
doctrine:
    dbal:
        driver:   pdo_sqlite
        path:     "%kernel.cache_dir%/__DBNAME__.db"
```

Where `__DBNAME__` will be replaced with ENV_TEST_CHANNEL_READABLE.value