### PR TITLE
Advocate stable tag in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ or simply add a dependency on liuggio/fastest to your project's composer.json fi
 
 	{
 	    "require-dev": {
-		    "liuggio/fastest": "dev-master"
+		    "liuggio/fastest": "~1.0"
 	    }
 	}
 


### PR DESCRIPTION
Locking on `dev-master` is a bad practice. We should advocate locking on stable tag.