### PR TITLE
Use putenv to set fastest enviroment variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,10 +257,6 @@ Options:
 
 ```
 
-### Known problems
-
-If you're faceing problems with unknown command errors, make sure your  [variables-order](http://us.php.net/manual/en/ini.core.php#ini.variables-order) `php.ini` setting contains `E`. If not, your enviroment variables are not set, and commands that are in your `PATH` will not work.
-
 ### Contribution
 
 Please help with code, love, feedback and bug reporting.

--- a/src/Process/EnvCommandCreator.php
+++ b/src/Process/EnvCommandCreator.php
@@ -10,16 +10,23 @@ class EnvCommandCreator
     const ENV_TEST_ARGUMENT = 'ENV_TEST_ARGUMENT';
     const ENV_TEST_INCREMENTAL_NUMBER = 'ENV_TEST_INC_NUMBER';
     const ENV_TEST_IS_FIRST_ON_CHANNEL = 'ENV_TEST_IS_FIRST_ON_CHANNEL';
-    // create an array of env
+
+    /**
+     * Injects parameters into enviroment variables.
+     *
+     * @param int    $i                     Channel number
+     * @param int    $maxProcesses          Max processes
+     * @param string $suite                 Suite
+     * @param int    $currentProcessCounter Current process counter
+     * @param bool   $isFirstOnItsThread    Is first on its thread?
+     */
     public function execute($i, $maxProcesses, $suite, $currentProcessCounter, $isFirstOnItsThread = false)
     {
-        return $_ENV + array(
-            self::ENV_TEST_CHANNEL.'='.(int) $i,
-            self::ENV_TEST_CHANNEL_READABLE.'=test_'.(int) $i,
-            self::ENV_TEST_CHANNELS_NUMBER.'='.(int) $maxProcesses,
-            self::ENV_TEST_ARGUMENT.'='.$suite,
-            self::ENV_TEST_INCREMENTAL_NUMBER.'='.(int) $currentProcessCounter,
-            self::ENV_TEST_IS_FIRST_ON_CHANNEL.'='.(int) $isFirstOnItsThread,
-        );
+        putenv(self::ENV_TEST_CHANNEL.'='.(int) $i);
+        putenv(self::ENV_TEST_CHANNEL_READABLE.'=test_'.(int) $i);
+        putenv(self::ENV_TEST_CHANNELS_NUMBER.'='.(int) $maxProcesses);
+        putenv(self::ENV_TEST_ARGUMENT.'='.$suite);
+        putenv(self::ENV_TEST_INCREMENTAL_NUMBER.'='.(int) $currentProcessCounter);
+        putenv(self::ENV_TEST_IS_FIRST_ON_CHANNEL.'='.(int) $isFirstOnItsThread);
     }
 }

--- a/src/Process/ProcessFactory.php
+++ b/src/Process/ProcessFactory.php
@@ -28,17 +28,33 @@ class ProcessFactory
     public function createAProcess($suite, $currentProcessorNumber, $currentProcessCounter, $isFirstOnThread = false)
     {
         $cmd = $this->replaceParameters($this->commandToExecuteTemplate, $suite, $currentProcessorNumber);
-        $arrayEnv = $this->envCommandCreator->execute($currentProcessorNumber, $this->maxParallelProcessesToExecute, $suite, $currentProcessCounter, $isFirstOnThread);
 
-        return $this->createProcess($cmd, $arrayEnv);
+        // inject enviroment variables
+        $this->envCommandCreator->execute(
+            $currentProcessorNumber,
+            $this->maxParallelProcessesToExecute,
+            $suite,
+            $currentProcessCounter,
+            $isFirstOnThread
+        );
+
+        return $this->createProcess($cmd);
     }
 
     public function createAProcessForACustomCommand($execute, $currentProcessorNumber, $currentProcessCounter, $isFirstOnThread = false)
     {
         $cmd = $this->replaceParameters($execute, '', $currentProcessorNumber);
-        $arrayEnv = $this->envCommandCreator->execute($currentProcessorNumber, $this->maxParallelProcessesToExecute, $execute, $currentProcessCounter, $isFirstOnThread);
 
-        return $this->createProcess($cmd, $arrayEnv);
+        // inject enviroment variables
+        $this->envCommandCreator->execute(
+            $currentProcessorNumber,
+            $this->maxParallelProcessesToExecute,
+            $execute,
+            $currentProcessCounter,
+            $isFirstOnThread
+        );
+
+        return $this->createProcess($cmd);
     }
 
     private function replaceParameters($cmd, $suite, $processNumber)
@@ -49,9 +65,13 @@ class ProcessFactory
         return $commandToExecute;
     }
 
-    private function createProcess($executeCommand, $arrayEnv)
+    private function createProcess($executeCommand)
     {
-        $process = new Process($executeCommand, null, $arrayEnv);
+        $process = new Process(
+            $executeCommand,
+            null,
+            null    // when passed null, process component should pick up current enviroment variables
+        );
 
         $process->setTimeout(null);
         // compatibility to SF 2.2

--- a/tests/Process/ProcessFactoryTest.php
+++ b/tests/Process/ProcessFactoryTest.php
@@ -2,10 +2,8 @@
 
 namespace Liuggio\Fastest\Process;
 
-
 class ProcessFactoryTest extends \PHPUnit_Framework_TestCase
 {
-
     /**
      * @test
      */
@@ -14,18 +12,20 @@ class ProcessFactoryTest extends \PHPUnit_Framework_TestCase
         $factory = new ProcessFactory(10);
         $process = $factory->createAProcess('fileA', 2, 10, true);
 
-        $this->assertEquals('bin/phpunit fileA', $process->getCommandLine());
-        $this->assertEquals(
-            $_ENV + array(
-                0 => 'ENV_TEST_CHANNEL=2',
-                1 => 'ENV_TEST_CHANNEL_READABLE=test_2',
-                2 => 'ENV_TEST_CHANNELS_NUMBER=10',
-                3 => 'ENV_TEST_ARGUMENT=fileA',
-                4 => 'ENV_TEST_INC_NUMBER=10',
-                5 => 'ENV_TEST_IS_FIRST_ON_CHANNEL=1'
-            ),
-            $process->getenv()
+        $expectedVariables = array(
+            'ENV_TEST_CHANNEL'             => 2,
+            'ENV_TEST_CHANNEL_READABLE'    => 'test_2',
+            'ENV_TEST_CHANNELS_NUMBER'     => 10,
+            'ENV_TEST_ARGUMENT'            => 'fileA',
+            'ENV_TEST_INC_NUMBER'          => 10,
+            'ENV_TEST_IS_FIRST_ON_CHANNEL' => 1,
         );
+
+        $this->assertEquals('bin/phpunit fileA', $process->getCommandLine());
+
+        foreach($expectedVariables as $key => $value) {
+            $this->assertEquals($value, getenv($key));
+        }
     }
 
     /**
@@ -36,18 +36,20 @@ class ProcessFactoryTest extends \PHPUnit_Framework_TestCase
         $factory = new ProcessFactory(11, 'execute');
         $process = $factory->createAProcess('fileA', 2, 12, false);
 
-        $this->assertEquals('execute', $process->getCommandLine());
-        $this->assertEquals(
-            $_ENV + array(
-                0 => 'ENV_TEST_CHANNEL=2',
-                1 => 'ENV_TEST_CHANNEL_READABLE=test_2',
-                2 => 'ENV_TEST_CHANNELS_NUMBER=11',
-                3 => 'ENV_TEST_ARGUMENT=fileA',
-                4 => 'ENV_TEST_INC_NUMBER=12',
-                5 => 'ENV_TEST_IS_FIRST_ON_CHANNEL=0'
-            ),
-            $process->getenv()
+        $expectedVariables = array(
+            'ENV_TEST_CHANNEL'             => 2,
+            'ENV_TEST_CHANNEL_READABLE'    => 'test_2',
+            'ENV_TEST_CHANNELS_NUMBER'     => 11,
+            'ENV_TEST_ARGUMENT'            => 'fileA',
+            'ENV_TEST_INC_NUMBER'          => 12,
+            'ENV_TEST_IS_FIRST_ON_CHANNEL' => 0,
         );
+
+        $this->assertEquals('execute', $process->getCommandLine());
+
+        foreach($expectedVariables as $key => $value) {
+            $this->assertEquals($value, getenv($key));
+        }
     }
 
     /**
@@ -58,18 +60,20 @@ class ProcessFactoryTest extends \PHPUnit_Framework_TestCase
         $factory = new ProcessFactory(12, 'execute {p} {}');
         $process = $factory->createAProcess('fileA', 1, 13, true);
 
-        $this->assertEquals('execute 1 fileA', $process->getCommandLine());
-        $this->assertEquals(
-            $_ENV + array(
-                0 => 'ENV_TEST_CHANNEL=1',
-                1 => 'ENV_TEST_CHANNEL_READABLE=test_1',
-                2 => 'ENV_TEST_CHANNELS_NUMBER=12',
-                3 => 'ENV_TEST_ARGUMENT=fileA',
-                4 => 'ENV_TEST_INC_NUMBER=13',
-                5 => 'ENV_TEST_IS_FIRST_ON_CHANNEL=1'
-            ),
-            $process->getenv()
+        $expectedVariables = array(
+            'ENV_TEST_CHANNEL'             => 1,
+            'ENV_TEST_CHANNEL_READABLE'    => 'test_1',
+            'ENV_TEST_CHANNELS_NUMBER'     => 12,
+            'ENV_TEST_ARGUMENT'            => 'fileA',
+            'ENV_TEST_INC_NUMBER'          => 13,
+            'ENV_TEST_IS_FIRST_ON_CHANNEL' => 1,
         );
+
+        $this->assertEquals('execute 1 fileA', $process->getCommandLine());
+
+        foreach($expectedVariables as $key => $value) {
+            $this->assertEquals($value, getenv($key));
+        }
     }
 }
  

--- a/tests/Process/ProcessesManagerTest.php
+++ b/tests/Process/ProcessesManagerTest.php
@@ -22,7 +22,7 @@ class ProcessesManagerTest extends \PHPUnit_Framework_TestCase
         $factory->expects($this->once())
             ->method('createAProcessForACustomCommand')
             ->with($this->anything(), $this->equalTo(1), $this->equalTo(1), $this->equalTo(true))
-            ->willReturn(new Process('echo ',rand()));
+            ->willReturn(new Process('echo '.rand()));
 
         $manager = new ProcessesManager($factory, 1, 'echo "ciao"');
 


### PR DESCRIPTION
As suggested by @Seldaek we're passing `null` to Symfony's Process component, which results in useing current ENV variables. Just before creating the process we use `putenv` to inject fastest variables. This solution does not depend on `php.ini` settings.