### PR TITLE
Add symfony3 compability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: php
 
-php: [5.3, 5.4, 5.5, 5.6, hhvm-nightly]
+php: [5.3, 5.4, 5.5, 5.6, 7.0, hhvm-nightly]
 
 matrix:
   allow_failures:
-    - php: hhvm-nightly
+    - php: [7.0, hhvm-nightly]
 
 before_script:
   - composer selfupdate

--- a/README.md
+++ b/README.md
@@ -215,13 +215,13 @@ or simply add a dependency on liuggio/fastest to your project's composer.json fi
 
 	{
 	    "require-dev": {
-		    "liuggio/fastest": "~1.2"
+		    "liuggio/fastest": "~1.3"
 	    }
 	}
 
 For a system-wide installation via Composer, you can run:
 
-`composer global require "liuggio/fastest=~1.2"`
+`composer global require "liuggio/fastest=~1.3"`
 
 Make sure you have `~/.composer/vendor/bin/` in your path,
 read more at [getcomposer.org](https://getcomposer.org/doc/00-intro.md#globally)

--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,9 @@
         }
     ],
     "require": {
-        "symfony/console": "~2.2",
-        "symfony/stopwatch": "~2.2",
-        "symfony/process": "~2.2",
+        "symfony/console": "~2.2|~3.0",
+        "symfony/stopwatch": "~2.2|~3.0",
+        "symfony/process": "~2.2|~3.0",
         "doctrine/collections" : "~1.2"
     },
     "require-dev": {
@@ -23,7 +23,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.3-dev"
+            "dev-master": "1.4-dev"
         }
     },
     "suggest": {

--- a/src/Process/EnvCommandCreator.php
+++ b/src/Process/EnvCommandCreator.php
@@ -10,16 +10,18 @@ class EnvCommandCreator
     const ENV_TEST_ARGUMENT = 'ENV_TEST_ARGUMENT';
     const ENV_TEST_INCREMENTAL_NUMBER = 'ENV_TEST_INC_NUMBER';
     const ENV_TEST_IS_FIRST_ON_CHANNEL = 'ENV_TEST_IS_FIRST_ON_CHANNEL';
+
     // create an array of env
     public function execute($i, $maxProcesses, $suite, $currentProcessCounter, $isFirstOnItsThread = false)
     {
-        return $_ENV + array(
+        return array(
             self::ENV_TEST_CHANNEL.'='.(int) $i,
             self::ENV_TEST_CHANNEL_READABLE.'=test_'.(int) $i,
             self::ENV_TEST_CHANNELS_NUMBER.'='.(int) $maxProcesses,
             self::ENV_TEST_ARGUMENT.'='.$suite,
             self::ENV_TEST_INCREMENTAL_NUMBER.'='.(int) $currentProcessCounter,
             self::ENV_TEST_IS_FIRST_ON_CHANNEL.'='.(int) $isFirstOnItsThread,
+            'PATH='.getenv('PATH'),
         );
     }
 }

--- a/tests/Process/ProcessFactoryTest.php
+++ b/tests/Process/ProcessFactoryTest.php
@@ -16,13 +16,14 @@ class ProcessFactoryTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('bin/phpunit fileA', $process->getCommandLine());
         $this->assertEquals(
-            $_ENV + array(
+            array(
                 0 => 'ENV_TEST_CHANNEL=2',
                 1 => 'ENV_TEST_CHANNEL_READABLE=test_2',
                 2 => 'ENV_TEST_CHANNELS_NUMBER=10',
                 3 => 'ENV_TEST_ARGUMENT=fileA',
                 4 => 'ENV_TEST_INC_NUMBER=10',
-                5 => 'ENV_TEST_IS_FIRST_ON_CHANNEL=1'
+                5 => 'ENV_TEST_IS_FIRST_ON_CHANNEL=1',
+                6 => 'PATH='.getenv('PATH')
             ),
             $process->getenv()
         );
@@ -38,13 +39,14 @@ class ProcessFactoryTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('execute', $process->getCommandLine());
         $this->assertEquals(
-            $_ENV + array(
+            array(
                 0 => 'ENV_TEST_CHANNEL=2',
                 1 => 'ENV_TEST_CHANNEL_READABLE=test_2',
                 2 => 'ENV_TEST_CHANNELS_NUMBER=11',
                 3 => 'ENV_TEST_ARGUMENT=fileA',
                 4 => 'ENV_TEST_INC_NUMBER=12',
-                5 => 'ENV_TEST_IS_FIRST_ON_CHANNEL=0'
+                5 => 'ENV_TEST_IS_FIRST_ON_CHANNEL=0',
+                6 => 'PATH='.getenv('PATH')
             ),
             $process->getenv()
         );
@@ -60,13 +62,14 @@ class ProcessFactoryTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('execute 1 fileA', $process->getCommandLine());
         $this->assertEquals(
-            $_ENV + array(
+            array(
                 0 => 'ENV_TEST_CHANNEL=1',
                 1 => 'ENV_TEST_CHANNEL_READABLE=test_1',
                 2 => 'ENV_TEST_CHANNELS_NUMBER=12',
                 3 => 'ENV_TEST_ARGUMENT=fileA',
                 4 => 'ENV_TEST_INC_NUMBER=13',
-                5 => 'ENV_TEST_IS_FIRST_ON_CHANNEL=1'
+                5 => 'ENV_TEST_IS_FIRST_ON_CHANNEL=1',
+                6 => 'PATH='.getenv('PATH')
             ),
             $process->getenv()
         );

--- a/tests/Process/ProcessesManagerTest.php
+++ b/tests/Process/ProcessesManagerTest.php
@@ -22,7 +22,7 @@ class ProcessesManagerTest extends \PHPUnit_Framework_TestCase
         $factory->expects($this->once())
             ->method('createAProcessForACustomCommand')
             ->with($this->anything(), $this->equalTo(1), $this->equalTo(1), $this->equalTo(true))
-            ->willReturn(new Process('echo ',rand()));
+            ->willReturn(new Process('echo '.rand(), sys_get_temp_dir()));
 
         $manager = new ProcessesManager($factory, 1, 'echo "ciao"');
 


### PR DESCRIPTION
This PR started of with adding symfony3 compability, however a few other fixes are included:
* require allows symfony3 components
* bumped minor version in doc and composer.json
* replaced `$_ENV` with `getenv('PATH')` and adjusted tests
* added PHP 7.0 to travis config (allowed failure)