### PR TITLE
Full enviroment table fallback

### DIFF
--- a/src/Process/EnvCommandCreator.php
+++ b/src/Process/EnvCommandCreator.php
@@ -14,7 +14,7 @@ class EnvCommandCreator
     // create an array of env
     public function execute($i, $maxProcesses, $suite, $currentProcessCounter, $isFirstOnItsThread = false)
     {
-        return array(
+        return $_ENV + array(
             self::ENV_TEST_CHANNEL.'='.(int) $i,
             self::ENV_TEST_CHANNEL_READABLE.'=test_'.(int) $i,
             self::ENV_TEST_CHANNELS_NUMBER.'='.(int) $maxProcesses,

--- a/tests/Process/ProcessFactoryTest.php
+++ b/tests/Process/ProcessFactoryTest.php
@@ -16,7 +16,7 @@ class ProcessFactoryTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('bin/phpunit fileA', $process->getCommandLine());
         $this->assertEquals(
-            array(
+            $_ENV + array(
                 0 => 'ENV_TEST_CHANNEL=2',
                 1 => 'ENV_TEST_CHANNEL_READABLE=test_2',
                 2 => 'ENV_TEST_CHANNELS_NUMBER=10',
@@ -39,7 +39,7 @@ class ProcessFactoryTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('execute', $process->getCommandLine());
         $this->assertEquals(
-            array(
+            $_ENV + array(
                 0 => 'ENV_TEST_CHANNEL=2',
                 1 => 'ENV_TEST_CHANNEL_READABLE=test_2',
                 2 => 'ENV_TEST_CHANNELS_NUMBER=11',
@@ -62,7 +62,7 @@ class ProcessFactoryTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('execute 1 fileA', $process->getCommandLine());
         $this->assertEquals(
-            array(
+            $_ENV + array(
                 0 => 'ENV_TEST_CHANNEL=1',
                 1 => 'ENV_TEST_CHANNEL_READABLE=test_1',
                 2 => 'ENV_TEST_CHANNELS_NUMBER=12',


### PR DESCRIPTION
It seems removeing the `$_ENV` was premature, as some other enviroment variables are needed sometimes.
Eg. symfony2.8, I can't connect to database - same command: `app/console doctrine:database:drop` 
* executed directly - works
* executed via fastest - does not work
* executed via fastest with `$_ENV` and `variables_order=EGCPS` (in `php.ini`) - works again