### PR TITLE
Fixes #72: Improve Travis CI tests:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,20 @@ php: [5.3, 5.4, 5.5, 5.6, 7.0, hhvm]
 
 matrix:
   allow_failures:
-    - php: 7.0
     - php: hhvm
+  fast_finish: true
+
+cache:
+  directories:
+    - $HOME/.composer/cache
 
 before_script:
   - composer selfupdate
-  - composer install --prefer-source
+  - composer install
 
 script:
   - find tests/ -name "*Test.php" | php fastest -v
   - bin/behat --config=adapters/Behat2/behat.yml
-  - sed -i -e 's/"behat\/behat"\x3A "~.*/"behat\/behat"\x3A "~3.1"/' composer.json
-  - composer update --prefer-source
+  - composer require --dev "behat/behat:~3.1" --no-update # update the Behat version.
+  - composer update
   - bin/behat --config=adapters/Behat/behat.yml

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ If you want to use it with phpunit you may want to install phpunit/phpunit as de
 
 ### Run this test with `fastest`
 
-**Easy** see [.travis.yml](.travis.yml#L14) file
+**Easy** see [.travis.yml](.travis.yml#L18) file
 
 ## The arguments:
 


### PR DESCRIPTION
Add Composer cache in Travis CI's cache
Remove PHP 7.0 from allowed failures
Use "composer require …" instead of "sed …"