### PR TITLE
Phpunit Loader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-php: [5.3, 5.4, 5.5, 5.6, 7.0, hhvm]
+php: [5.6, 7.0, hhvm]
 
 matrix:
   allow_failures:

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         }
     ],
     "require": {
+        "php": ">=5.6",
         "symfony/console": "~2.7|~3.0",
         "symfony/stopwatch": "~2.7|~3.0",
         "symfony/process": "~2.7|~3.0",
@@ -27,7 +28,6 @@
         }
     },
     "suggest": {
-        "phpunit/phpunit": "Install it if you want to run test on /bin/phpunit",
         "behat/behat": "Install it if you want to run tests with the provided Behat extension"
     },
     "bin": [

--- a/composer.json
+++ b/composer.json
@@ -9,13 +9,13 @@
         }
     ],
     "require": {
-        "symfony/console": "~2.2|~3.0",
-        "symfony/stopwatch": "~2.2|~3.0",
-        "symfony/process": "~2.2|~3.0",
-        "doctrine/collections" : "~1.2"
+        "symfony/console": "~2.7|~3.0",
+        "symfony/stopwatch": "~2.7|~3.0",
+        "symfony/process": "~2.7|~3.0",
+        "doctrine/collections" : "~1.2",
+        "phpunit/phpunit": "~4.8|~5.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8|~5.4",
         "behat/behat": "~2.5"
     },
     "config": {

--- a/src/Command/ParallelCommand.php
+++ b/src/Command/ParallelCommand.php
@@ -8,6 +8,7 @@ use Liuggio\Fastest\Queue\TestsQueue;
 use Liuggio\Fastest\UI\ProgressBarRenderer;
 use Liuggio\Fastest\UI\VerboseRenderer;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -131,7 +132,7 @@ class ParallelCommand extends Command
         if ($this->isVerbose($output)) {
             $progressBar = new VerboseRenderer($queue->count(), $this->hasErrorSummary($input), $output, $processManager->getNumberOfProcessExecutedByTheBeforeCommand());
         } else {
-            $progressBar = new ProgressBarRenderer($queue->count(),$this->hasErrorSummary($input), $output, $this->getHelper('progress'), $processManager->getNumberOfProcessExecutedByTheBeforeCommand());
+            $progressBar = new ProgressBarRenderer($queue->count(),$this->hasErrorSummary($input), $output, new ProgressBar($output), $processManager->getNumberOfProcessExecutedByTheBeforeCommand());
         }
 
         $progressBar->renderHeader($queue);

--- a/src/Queue/CreateTestsQueueFromPhpUnitXML.php
+++ b/src/Queue/CreateTestsQueueFromPhpUnitXML.php
@@ -6,36 +6,16 @@ class CreateTestsQueueFromPhpUnitXML
 {
     public static function execute($xmlFile)
     {
-        $simpleObject = self::readFromXml($xmlFile);
-        $arrayOfStrings = self::extractSuitesFromXmlObject($simpleObject);
+        $configuration = \PHPUnit_Util_Configuration::getInstance($xmlFile);
         $testSuites = new TestsQueue();
 
-        foreach ($arrayOfStrings as $string) {
-            $testSuites->add($string);
+        /** @var \PHPUnit_Framework_TestSuite $bla */
+        foreach ($configuration->getTestSuiteConfiguration()->getIterator() as $testSuite)
+        {
+            $class = new \ReflectionClass($testSuite->getName());
+            $testSuites->add($class->getFileName());
         }
 
         return $testSuites;
-    }
-
-    private static function readFromXml($filename)
-    {
-        if (file_exists($filename)) {
-            return simplexml_load_file($filename);
-        }
-
-        throw new \Exception('Failed to open $filename.');
-    }
-
-    private static function extractSuitesFromXmlObject(\SimpleXMLElement $simpleObject)
-    {
-        $directories = null;
-        if (isset($simpleObject->testsuites)
-            && isset($simpleObject->testsuites->testsuite)
-            && isset($simpleObject->testsuites->testsuite->directory)
-        ) {
-            $directories = $simpleObject->testsuites->testsuite->directory;
-        }
-
-        return $directories;
     }
 }

--- a/tests/Queue/CreateTestsQueueFromPhpUnitXMLTest.php
+++ b/tests/Queue/CreateTestsQueueFromPhpUnitXMLTest.php
@@ -12,7 +12,14 @@ class CreateTestsQueueFromPhpUnitXMLTest extends \PHPUnit_Framework_TestCase
     {
         $output = CreateTestsQueueFromPhpUnitXML::execute(__DIR__.'/Fixture/phpunit.xml.dist');
 
-        $this->assertEquals(new TestsQueue(array('tests/Fastest/folderA', 'tests/Fastest/folderB')), $output);
+        $directory = __DIR__ . '/Infrastructure/';
+        $files = array('InMemoryQueueFactoryTest.php', 'InMemoryQueueTest.php');
+        $queue = new TestsQueue();
+
+        foreach ($files as $file) {
+            $queue->add($directory . $file);
+        }
+
+        $this->assertEquals($queue, $output);
     }
 }
- 

--- a/tests/Queue/Fixture/phpunit.xml.dist
+++ b/tests/Queue/Fixture/phpunit.xml.dist
@@ -2,15 +2,8 @@
 
 <phpunit bootstrap="tests/bootstrap.php" colors="true">
     <testsuites>
-        <testsuite name="Price Test Suite">
-            <directory>tests/Fastest/folderA</directory>
-            <directory>tests/Fastest/folderB</directory>
+        <testsuite name="Project Test Suite">
+            <directory>../Infrastructure/</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/tests/Queue/ReadFromInputAndPushIntoTheQueueTest.php
+++ b/tests/Queue/ReadFromInputAndPushIntoTheQueueTest.php
@@ -10,9 +10,15 @@ class ReadFromInputAndPushIntoTheQueueTest extends \PHPUnit_Framework_TestCase {
      */
     public function shouldPushIntoTheQueueTheXMLFile()
     {
-        $assertion = new TestsQueue(array('tests/Fastest/folderA', 'tests/Fastest/folderB'));
+        $directory = __DIR__ . '/Infrastructure/';
+        $files = array('InMemoryQueueFactoryTest.php', 'InMemoryQueueTest.php');
+        $assertion = new TestsQueue();
 
-        $queue = $this->getMock('\Liuggio\Fastest\Queue\QueueInterface');
+        foreach ($files as $file) {
+            $assertion->add($directory . $file);
+        }
+
+        $queue = $this->createMock('\Liuggio\Fastest\Queue\QueueInterface');
         $queue->expects($this->once())
             ->method('push')
             ->with($assertion);
@@ -32,4 +38,3 @@ class ReadFromInputAndPushIntoTheQueueTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals($queue, $ret);
     }
 }
- 


### PR DESCRIPTION
SF 3.x compatibility due to the deprecated progress helper (Had to bump Symfony version therefore)

I also added a way to fix issues with handling of PHPUnit configuration files.

Tickets:
- fixes #26 