### PR TITLE
manage sqlite master slave database path

### DIFF
--- a/adapters/Doctrine/DBAL/ConnectionFactory.php
+++ b/adapters/Doctrine/DBAL/ConnectionFactory.php
@@ -24,10 +24,26 @@ class ConnectionFactory extends BaseConnectionFactory
      */
     public function createConnection(array $params, Configuration $config = null, EventManager $eventManager = null, array $mappingTypes = array())
     {
-        $dbName = $this->getDbNameFromEnv($params['dbname']);
-                
+        if (isset($params['dbname'])) {
+            $dbName = $this->getDbNameFromEnv($params['dbname']);
+        } else {
+            $dbName = $this->getDbNameFromEnv($params['master']['dbname']);
+        }
+
         if ($params['driver'] === 'pdo_sqlite') {
-            $params['path'] = str_replace("__DBNAME__", $dbName, $params['path']);
+            if (isset($params['path'])) {
+                $params['path'] = str_replace("__DBNAME__", $dbName, $params['path']);
+            }
+
+            if (isset($params['master']['path'])) {
+                $params['master']['path'] = str_replace("__DBNAME__", $dbName, $params['master']['path']);
+            }
+
+            if (!empty($params['slaves'])) {
+                foreach ($params['slaves'] as &$slave) {
+                    $slave['path'] = str_replace("__DBNAME__", $dbName, $slave['path']);
+                }
+            }
         } else {
             $params['dbname'] = $dbName;
         }


### PR DESCRIPTION
If you work on a master/slave connection, the `dbname` parameter does not exists and is set in the `master` key. 

Same for the `path` stored in `master` key and each `slave`