### PR TITLE
Add 1.4 phar and box build config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor
 composer.lock
 bin
 docs/_build
+.idea

--- a/box.json
+++ b/box.json
@@ -1,0 +1,6 @@
+{
+    "directories": ["src", "vendor"],
+    "main": "fastest",
+    "output": "fastest.phar",
+    "stub": true
+}


### PR DESCRIPTION
Fixes #81

* built current `1.4` version phar with [box-project/box2](https://github.com/box-project/box2)
* added `box.json` build config
* (misc) added phpstorm project dir `.idea` to gitignore file

To build new phar (assuming we have box installed globally in our system) just go to fastest project dir and command `box build`