### PR TITLE
Update core.xml

### DIFF
--- a/adapters/Behat/ListFeaturesExtension/services/core.xml
+++ b/adapters/Behat/ListFeaturesExtension/services/core.xml
@@ -12,7 +12,7 @@
         <service id="liuggio.fastest.behat.list_features.console.processor.list_features" class="%liuggio.fastest.behat.list_features_extension.console.processor.list_features.class%">
             <argument type="service" id="specifications.locator.filesystem_feature" />
             <argument type="service" id="suite.registry" />
-            <tag name="cli.controller" priority="100" />
+            <tag name="cli.controller" priority="255" />
         </service>
 
     </services>


### PR DESCRIPTION
I'm using behat 3.3.0 and I've noticed that `--list-scenarios` won't work anymore if `priority` in this service is 100 (old value).
Now I've tested it with 255 (highest possibile based on symfony standards) and this seems to work again.

Is 255 acceptable for you?
Do I need to add behat 3.3.0 in travis?