### PR TITLE
Proper require-dev due to PHPUnit 6 conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
         "symfony/console": "~2.7|~3.0",
         "symfony/stopwatch": "~2.7|~3.0",
         "symfony/process": "~2.7|~3.0",
-        "doctrine/collections" : "~1.2",
-        "phpunit/phpunit": "~4.8|~5.4"
+        "doctrine/collections" : "~1.2"
     },
     "require-dev": {
-        "behat/behat": "~2.5"
+        "behat/behat": "~2.5",
+        "phpunit/phpunit": "~4.8|~5.4"
     },
     "config": {
         "bin-dir": "bin/"


### PR DESCRIPTION
We need to have PHPUnit 6, but this one blocked by package requirement