### PR TITLE
Add the Windows compatibility for the processor counter

### DIFF
--- a/src/Process/ProcessorCounter.php
+++ b/src/Process/ProcessorCounter.php
@@ -2,6 +2,8 @@
 
 namespace Liuggio\Fastest\Process;
 
+use Symfony\Component\Process\Process;
+
 /**
  *  Number of processors seen by the OS and used for process scheduling.
  */
@@ -45,6 +47,13 @@ class ProcessorCounter
                     return substr_count($contents, 'processor');
                 } catch (\Exception $e) {
                 }
+            }
+        } elseif ('\\' === DIRECTORY_SEPARATOR) {
+            $process = new Process('for /F "tokens=2 delims==" %C in (\'wmic cpu get NumberOfLogicalProcessors /value ^| findstr NumberOfLogicalProcessors\') do @echo %C');
+            $process->run();
+
+            if ($process->isSuccessful() && ($numProc = intval($process->getOutput())) > 0) {
+                return $numProc;
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1
| License       | MIT
| Doc PR        | ~

This PR add the compatibility Windows to retrieve automatically the number of logical processors.