### PR TITLE
Fix Windows compatibility

### DIFF
--- a/src/Process/ProcessFactory.php
+++ b/src/Process/ProcessFactory.php
@@ -6,8 +6,6 @@ use Symfony\Component\Process\Process;
 
 class ProcessFactory
 {
-    const DEFAULT_COMMAND_TO_EXECUTE_TPL = 'bin/phpunit {}';
-
     private $envCommandCreator;
     private $commandToExecuteTemplate;
     private $maxParallelProcessesToExecute;
@@ -18,7 +16,7 @@ class ProcessFactory
             $envCommandCreator = new EnvCommandCreator();
         }
         if (null === $commandToExecuteTemplate || empty($commandToExecuteTemplate)) {
-            $commandToExecuteTemplate = self::DEFAULT_COMMAND_TO_EXECUTE_TPL;
+            $commandToExecuteTemplate = self::getDefaultCommandToExecute();
         }
         $this->maxParallelProcessesToExecute = $maxParallelProcessesToExecute;
         $this->envCommandCreator = $envCommandCreator;
@@ -52,6 +50,10 @@ class ProcessFactory
 
     private function createProcess($executeCommand, $arrayEnv)
     {
+        if ('\\' === DIRECTORY_SEPARATOR) {
+            $arrayEnv = array_merge($_SERVER, $arrayEnv);
+        }
+
         $process = new Process($executeCommand, null, $arrayEnv);
 
         $process->setTimeout(null);
@@ -61,5 +63,12 @@ class ProcessFactory
         }
 
         return $process;
+    }
+
+    public static function getDefaultCommandToExecute()
+    {
+        return ('\\' === DIRECTORY_SEPARATOR)
+            ? 'bin\phpunit {}'
+            : 'bin/phpunit {}';
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #24
| License       | MIT
| Doc PR        | ~

On Windows, there is a bug to pass the environment variable into process (see https://php.net/manual/en/function.proc-open.php#117912).

Symfony Process fix this bug since the 3.2 version, but you must call the method `Process::inheritEnvironmentVariables()` to pass the environment variables into the process (see symfony/symfony#19053).

Since the 3.3 version, this method is deprecated because all environement variables are passed into the process if no custom variables are used (see symfony/symfony#21470).

However, Fastest use the custom environment variables, and this PR add the environement variables into the process and fix the default command for Phpunit with Windows.

For example, with this PR, the tests are ok with Phpunit and Symfony 4.0 Flex and the environment variables configuration.