### PR TITLE
Improve Behat list scenarios for Outline scenarios

### DIFF
--- a/adapters/Behat/ListFeaturesExtension/Console/Processor/ListFeaturesProcessor.php
+++ b/adapters/Behat/ListFeaturesExtension/Console/Processor/ListFeaturesProcessor.php
@@ -2,6 +2,7 @@
 
 namespace Liuggio\Fastest\Behat\ListFeaturesExtension\Console\Processor;
 
+use Behat\Gherkin\Node\OutlineNode;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -85,8 +86,16 @@ class ListFeaturesProcessor implements Controller
             foreach ($this->locator->locateSpecifications($suite, '') as $feature) {
                 foreach ($feature->getScenarios() as $key => $scenario) {
                     $file = $feature->getFile();
-                    $lineNo = $scenario->getLine();
-                    $scenarios[] = "$file:$lineNo";
+                    $lines = [$scenario->getLine()];
+
+                    if ($scenario instanceof OutlineNode) {
+                        $lines = $scenario->getExampleTable()->getLines();
+                        array_shift($lines);
+                    }
+
+                    foreach ($lines as $line) {
+                        $scenarios[] = "$file:$line";
+                    }
                 }
             }
         }

--- a/adapters/Behat/features/listFeatures.feature
+++ b/adapters/Behat/features/listFeatures.feature
@@ -27,6 +27,8 @@ Scenario: The --list-scenarios command outputs each feature with the line number
   """
   features/firstfeature.feature:3
   features/firstfeature.feature:8
+  features/firstfeature.feature:18
+  features/firstfeature.feature:19
   features/secondfeature.feature:3
   features/secondfeature.feature:7
   features/secondfeature.feature:12

--- a/adapters/Behat/features/testResources/features/firstfeature.feature.resource
+++ b/adapters/Behat/features/testResources/features/firstfeature.feature.resource
@@ -8,3 +8,12 @@ Feature: First feature
   Scenario: Scenario in line 8
     Given Step four
     Then Step one
+
+  Scenario Outline: Scenario in line 12
+    Given Step <first>
+    Then Step <second>
+
+    Examples:
+      | first | second |
+      | A     | B      |
+      | C     | D      |

--- a/adapters/Behat2/ListFeaturesExtension/Console/Processor/ListFeaturesProcessor.php
+++ b/adapters/Behat2/ListFeaturesExtension/Console/Processor/ListFeaturesProcessor.php
@@ -2,6 +2,7 @@
 
 namespace Liuggio\Fastest\Behat2\ListFeaturesExtension\Console\Processor;
 
+use Behat\Gherkin\Node\OutlineNode;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Console\Command\Command;
@@ -91,8 +92,16 @@ class ListFeaturesProcessor extends BaseProcessor
             /* @var $scenario \Behat\Gherkin\Node\ScenarioNode */
             foreach ($featureNode->getScenarios() as $scenario) {
                 $file = $scenario->getFile();
-                $lineNo = $scenario->getLine();
-                $scenarios[] = "$file:$lineNo";
+                $lines = [$scenario->getLine()];
+
+                if ($scenario instanceof OutlineNode) {
+                    $lines = $scenario->getExamples()->getRowLines();
+                    array_shift($lines);
+                }
+
+                foreach ($lines as $line) {
+                    $scenarios[] = "$file:$line";
+                }
             }
         }
 

--- a/adapters/Behat2/features/listFeatures.feature
+++ b/adapters/Behat2/features/listFeatures.feature
@@ -27,6 +27,8 @@ Scenario: The --list-scenarios command outputs each feature with the line number
   """
   features/firstfeature.feature:3
   features/firstfeature.feature:8
+  features/firstfeature.feature:18
+  features/firstfeature.feature:19
   features/secondfeature.feature:3
   features/secondfeature.feature:7
   features/secondfeature.feature:12

--- a/adapters/Behat2/features/testResources/features/firstfeature.feature.resource
+++ b/adapters/Behat2/features/testResources/features/firstfeature.feature.resource
@@ -8,3 +8,12 @@ Feature: First feature
   Scenario: Scenario in line 8
     Given Step four
     Then Step one
+
+  Scenario Outline: Scenario in line 12
+    Given Step <first>
+    Then Step <second>
+
+    Examples:
+      | first | second |
+      | A     | B      |
+      | C     | D      |


### PR DESCRIPTION
Hello,

I noticed that the `ListFeaturesExtension`, when used with `list-scenarios` consider `Scenario Outline` as one scenario but in our case they are the longest scenarios so it could be nice to split them as separated scenarios.