### PR TITLE
Fix the overriding of env variables for the phpunit config

### DIFF
--- a/src/Process/EnvCommandCreator.php
+++ b/src/Process/EnvCommandCreator.php
@@ -14,14 +14,13 @@ class EnvCommandCreator
     // create an array of env
     public function execute($i, $maxProcesses, $suite, $currentProcessCounter, $isFirstOnItsThread = false)
     {
-        return $_ENV + [
-            self::ENV_TEST_CHANNEL.'='.(int) $i,
-            self::ENV_TEST_CHANNEL_READABLE.'=test_'.(int) $i,
-            self::ENV_TEST_CHANNELS_NUMBER.'='.(int) $maxProcesses,
-            self::ENV_TEST_ARGUMENT.'='.$suite,
-            self::ENV_TEST_INCREMENTAL_NUMBER.'='.(int) $currentProcessCounter,
-            self::ENV_TEST_IS_FIRST_ON_CHANNEL.'='.(int) $isFirstOnItsThread,
-            'PATH='.getenv('PATH'),
-        ];
+        return array_change_key_case($_SERVER + $_ENV + [
+            self::ENV_TEST_CHANNEL => (int) $i,
+            self::ENV_TEST_CHANNEL_READABLE => 'test_'.$i,
+            self::ENV_TEST_CHANNELS_NUMBER => (int) $maxProcesses,
+            self::ENV_TEST_ARGUMENT => (string) $suite,
+            self::ENV_TEST_INCREMENTAL_NUMBER => (int) $currentProcessCounter,
+            self::ENV_TEST_IS_FIRST_ON_CHANNEL => (int) $isFirstOnItsThread,
+        ], CASE_UPPER);
     }
 }

--- a/src/Process/ProcessFactory.php
+++ b/src/Process/ProcessFactory.php
@@ -50,10 +50,6 @@ class ProcessFactory
 
     private function createProcess($executeCommand, $arrayEnv)
     {
-        if ('\\' === DIRECTORY_SEPARATOR) {
-            $arrayEnv = array_merge($_SERVER, $arrayEnv);
-        }
-
         $process = new Process($executeCommand, null, $arrayEnv);
 
         $process->setTimeout(null);

--- a/src/Process/Processes.php
+++ b/src/Process/Processes.php
@@ -201,9 +201,9 @@ class Processes
     private function moveToCompletedProcesses($key, Process $process)
     {
         $env = $process->getEnv();
-        $suite = str_replace(EnvCommandCreator::ENV_TEST_ARGUMENT.'=', '', $env[3]);
-        $number = str_replace(EnvCommandCreator::ENV_TEST_CHANNEL.'=', '', $env[0]);
-        $numberOnThread = (int) str_replace(EnvCommandCreator::ENV_TEST_IS_FIRST_ON_CHANNEL.'=', '', $env[5]);
+        $suite = $env[EnvCommandCreator::ENV_TEST_ARGUMENT];
+        $number = $env[EnvCommandCreator::ENV_TEST_CHANNEL];
+        $numberOnThread = $env[EnvCommandCreator::ENV_TEST_IS_FIRST_ON_CHANNEL];
 
         if (!$process->isSuccessful()) {
             $this->errorCounter++;

--- a/tests/Process/ProcessFactoryTest.php
+++ b/tests/Process/ProcessFactoryTest.php
@@ -12,18 +12,19 @@ class ProcessFactoryTest extends \PHPUnit\Framework\TestCase
     {
         $factory = new ProcessFactory(10);
         $process = $factory->createAProcess('fileA', 2, 10, true);
+        $serverEnvs = $_SERVER;
+        unset($serverEnvs['argv']);
 
-        $this->assertEquals('bin/phpunit fileA', $process->getCommandLine());
+        $this->assertEquals('bin'.DIRECTORY_SEPARATOR.'phpunit fileA', $process->getCommandLine());
         $this->assertEquals(
-            $_ENV + [
-                0 => 'ENV_TEST_CHANNEL=2',
-                1 => 'ENV_TEST_CHANNEL_READABLE=test_2',
-                2 => 'ENV_TEST_CHANNELS_NUMBER=10',
-                3 => 'ENV_TEST_ARGUMENT=fileA',
-                4 => 'ENV_TEST_INC_NUMBER=10',
-                5 => 'ENV_TEST_IS_FIRST_ON_CHANNEL=1',
-                6 => 'PATH='.getenv('PATH')
-            ],
+            array_change_key_case($serverEnvs + $_ENV + [
+                'ENV_TEST_CHANNEL' => 2,
+                'ENV_TEST_CHANNEL_READABLE' => 'test_2',
+                'ENV_TEST_CHANNELS_NUMBER' => 10,
+                'ENV_TEST_ARGUMENT'=> 'fileA',
+                'ENV_TEST_INC_NUMBER' => 10,
+                'ENV_TEST_IS_FIRST_ON_CHANNEL' => 1,
+            ], CASE_UPPER),
             $process->getenv()
         );
     }
@@ -35,18 +36,19 @@ class ProcessFactoryTest extends \PHPUnit\Framework\TestCase
     {
         $factory = new ProcessFactory(11, 'execute');
         $process = $factory->createAProcess('fileA', 2, 12, false);
+        $serverEnvs = $_SERVER;
+        unset($serverEnvs['argv']);
 
         $this->assertEquals('execute', $process->getCommandLine());
         $this->assertEquals(
-            $_ENV + [
-                0 => 'ENV_TEST_CHANNEL=2',
-                1 => 'ENV_TEST_CHANNEL_READABLE=test_2',
-                2 => 'ENV_TEST_CHANNELS_NUMBER=11',
-                3 => 'ENV_TEST_ARGUMENT=fileA',
-                4 => 'ENV_TEST_INC_NUMBER=12',
-                5 => 'ENV_TEST_IS_FIRST_ON_CHANNEL=0',
-                6 => 'PATH='.getenv('PATH')
-            ],
+            array_change_key_case($serverEnvs + $_ENV + [
+                'ENV_TEST_CHANNEL' => 2,
+                'ENV_TEST_CHANNEL_READABLE' => 'test_2',
+                'ENV_TEST_CHANNELS_NUMBER' => 11,
+                'ENV_TEST_ARGUMENT'=> 'fileA',
+                'ENV_TEST_INC_NUMBER' => 12,
+                'ENV_TEST_IS_FIRST_ON_CHANNEL' => 0,
+            ], CASE_UPPER),
             $process->getenv()
         );
     }
@@ -58,18 +60,19 @@ class ProcessFactoryTest extends \PHPUnit\Framework\TestCase
     {
         $factory = new ProcessFactory(12, 'execute {p} {} {n}');
         $process = $factory->createAProcess('fileA', 1, 13, true);
+        $serverEnvs = $_SERVER;
+        unset($serverEnvs['argv']);
 
         $this->assertEquals('execute 1 fileA 13', $process->getCommandLine());
         $this->assertEquals(
-            $_ENV + [
-                0 => 'ENV_TEST_CHANNEL=1',
-                1 => 'ENV_TEST_CHANNEL_READABLE=test_1',
-                2 => 'ENV_TEST_CHANNELS_NUMBER=12',
-                3 => 'ENV_TEST_ARGUMENT=fileA',
-                4 => 'ENV_TEST_INC_NUMBER=13',
-                5 => 'ENV_TEST_IS_FIRST_ON_CHANNEL=1',
-                6 => 'PATH='.getenv('PATH')
-            ],
+            array_change_key_case($serverEnvs + $_ENV + [
+                'ENV_TEST_CHANNEL' => 1,
+                'ENV_TEST_CHANNEL_READABLE' => 'test_1',
+                'ENV_TEST_CHANNELS_NUMBER' => 12,
+                'ENV_TEST_ARGUMENT'=> 'fileA',
+                'ENV_TEST_INC_NUMBER' => 13,
+                'ENV_TEST_IS_FIRST_ON_CHANNEL' => 1,
+            ], CASE_UPPER),
             $process->getenv()
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ~
| License       | MIT
| Doc PR        | ~

With Symfony 4 Flex, it is now recommended to configure the environment variables in the phpunit XML configuration. Phpunit does not overwrite the existing environment variables with the default variables set in the XML configuration.

It works fine using Phpunit directly, however this is not the case using Fastest on linux (and therefore also Docker), but works for Windows. The PR #98 already made it possible to correct a problem of environment variable for Windows, but in this case, the problem is also present for all the platforms.

We could set in the `php.ini` file the value `variables_order=EGPCS` (`GPCS` by default), but it is recommended to use the `GPCS` value.

Therefore, it is preferable to merge the variables in `$_SERVER` with `$_ENV` like the [Symfony WebServerBundle](https://github.com/symfony/symfony/blob/4.0/src/Symfony/Bundle/WebServerBundle/Resources/router.php#L35).