### PR TITLE
Load the phpunit bootstrap file

### DIFF
--- a/src/Queue/CreateTestsQueueFromPhpUnitXML.php
+++ b/src/Queue/CreateTestsQueueFromPhpUnitXML.php
@@ -15,6 +15,10 @@ if (class_exists('\PHPUnit_Util_TestSuiteIterator')) {
     class_alias('\PHPUnit_Util_TestSuiteIterator', '\PHPUnit\Framework\TestSuiteIterator');
 }
 
+if (class_exists('\PHPUnit_Util_Fileloader')) {
+    class_alias('\PHPUnit_Util_Fileloader', '\PHPUnit\Util\Fileloader');
+}
+
 class CreateTestsQueueFromPhpUnitXML
 {
     public static function execute($xmlFile)
@@ -22,6 +26,7 @@ class CreateTestsQueueFromPhpUnitXML
         $configuration = \PHPUnit\Util\Configuration::getInstance($xmlFile);
         $testSuites = new TestsQueue();
 
+        self::handleBootstrap($configuration->getPHPUnitConfiguration());
         self::processTestSuite($testSuites, $configuration->getTestSuiteConfiguration()->getIterator());
 
         return $testSuites;
@@ -45,5 +50,17 @@ class CreateTestsQueueFromPhpUnitXML
             $class = new \ReflectionClass($name);
             $testSuites->add($class->getFileName());
         }
+    }
+
+    /**
+     * Loads a bootstrap file.
+     *
+     * @param array $config The Phpunit config
+     */
+    private static function handleBootstrap(array $config)
+    {
+        $filename = isset($config['bootstrap']) ? $config['bootstrap'] : 'vendor/autoload.php';
+
+        \PHPUnit\Util\Fileloader::checkAndLoad($filename);
     }
 }

--- a/tests/Queue/Fixture/tests/bootstrap.php
+++ b/tests/Queue/Fixture/tests/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+return require __DIR__.'/../../../../vendor/autoload.php';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ~
| License       | MIT
| Doc PR        | ~

The Phpunit bootstrap file is not loaded, and it's problematic with a custom bootstrap file in global installation.

This PR add the possibility to use a custom bootstrap file defined in the Phpunit configuration file.