### PR TITLE
Allow to install Fastest in global mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Our old codebase run in 30 minutes, now in 7 minutes with 4 Processors.
 4. As input you could use a `phpunit.xml.dist` file or use pipe (see below).
 5. Includes a Behat extension to easily pipe scenarios into fastest.
 6. Increase Verbosity with -v option.
+7. Works with a installation in project or global mode
 
 ## How
 

--- a/src/Process/ProcessFactory.php
+++ b/src/Process/ProcessFactory.php
@@ -10,6 +10,8 @@ class ProcessFactory
     private $commandToExecuteTemplate;
     private $maxParallelProcessesToExecute;
 
+    private static $cacheBinCmd;
+
     public function __construct($maxParallelProcessesToExecute, $commandToExecuteTemplate = null, EnvCommandCreator $envCommandCreator = null)
     {
         if (null === $envCommandCreator) {
@@ -67,8 +69,41 @@ class ProcessFactory
 
     public static function getDefaultCommandToExecute()
     {
-        return ('\\' === DIRECTORY_SEPARATOR)
-            ? 'bin\phpunit {}'
-            : 'bin/phpunit {}';
+        if (null !== self::$cacheBinCmd) {
+            return self::$cacheBinCmd;
+        }
+
+        return self::$cacheBinCmd = self::isWindows() ? self::getWindowsBinCmd() : self::getUnixBinCmd();
+    }
+
+    private static function isWindows()
+    {
+        return '\\' === DIRECTORY_SEPARATOR;
+    }
+
+    private static function getWindowsBinCmd()
+    {
+        if (file_exists(getcwd().'/bin/phpunit')) {
+            $cmd = 'bin\phpunit {}';
+        } elseif (file_exists(getenv('APPDATA').'\Composer\vendor\bin\phpunit')) {
+            $cmd = '%APPDATA%\Composer\vendor\bin\phpunit {}';
+        } else {
+            $cmd = 'phpunit {}';
+        }
+
+        return $cmd;
+    }
+
+    private static function getUnixBinCmd()
+    {
+        if (file_exists(getcwd().'/bin/phpunit')) {
+            $cmd = 'bin/phpunit {}';
+        } elseif (file_exists(getenv('HOME').'/.composer/vendor/bin/phpunit')) {
+            $cmd = '~/.composer/vendor/bin/phpunit {}';
+        } else {
+            $cmd = 'phpunit {}';
+        }
+
+        return $cmd;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ~
| License       | MIT
| Doc PR        | ~

The Symfony's team strongly recommend in Symfony 4 Flex should not add in the Phpunit dependencies in our projects, even in dev. So, it is recommended to install Phpunit globally. However, Fastest is not able to work in global mode.

This PR allow to install/use the Fastest in global mode with Phpunit.