### PR TITLE
Fix behavior variations of different versions of symfony process in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,13 @@ env:
     - PREFER_LOWEST=""
 
 matrix:
+  exclude:
+    - php: 5.6
+      env: PREFER_LOWEST=""
+    - php: 7.0
+      env: PREFER_LOWEST=""
+    - php: hhvm
+      env: PREFER_LOWEST=""
   allow_failures:
     - php: hhvm
   fast_finish: true
@@ -23,11 +30,13 @@ cache:
 
 before_script:
   - composer selfupdate
-  - composer install
+  - if [[ $TRAVIS_PHP_VERSION == 7.2 ]]; then
+      composer require "phpunit/phpunit:^6.1" --no-update;
+    else
+      composer require "phpunit/phpunit:^5.7" --no-update;
+    fi
+  - composer update $PREFER_LOWEST
 
 script:
   - find tests/ -name "*Test.php" | php fastest -v
-  - bin/behat --config=adapters/Behat2/behat.yml
-  - composer require --dev "behat/behat:~3.3" --no-update # update the Behat version.
-  - composer update $PREFER_LOWEST
   - bin/behat --config=adapters/Behat/behat.yml

--- a/composer.json
+++ b/composer.json
@@ -13,18 +13,17 @@
         "symfony/console": ">=2.7 <5.0",
         "symfony/stopwatch": ">=2.7 <5.0",
         "symfony/process": ">=2.7 <5.0",
-        "doctrine/collections" : "~1.2",
-        "phpunit/phpunit": "^5.7|^6.1"
+        "doctrine/collections" : "~1.2"
     },
     "require-dev": {
-        "behat/behat": "~2.5"
+        "behat/behat": "~3.3"
     },
     "config": {
         "bin-dir": "bin/"
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.5-dev"
+            "dev-master": "1.6-dev"
         }
     },
     "suggest": {

--- a/src/Process/EnvCommandCreator.php
+++ b/src/Process/EnvCommandCreator.php
@@ -14,7 +14,7 @@ class EnvCommandCreator
     // create an array of env
     public function execute($i, $maxProcesses, $suite, $currentProcessCounter, $isFirstOnItsThread = false)
     {
-        return array_change_key_case($_SERVER + $_ENV + [
+        return array_change_key_case(static::cleanEnvVariables($_SERVER) + $_ENV + [
             self::ENV_TEST_CHANNEL => (int) $i,
             self::ENV_TEST_CHANNEL_READABLE => 'test_'.$i,
             self::ENV_TEST_CHANNELS_NUMBER => (int) $maxProcesses,
@@ -22,5 +22,21 @@ class EnvCommandCreator
             self::ENV_TEST_INCREMENTAL_NUMBER => (int) $currentProcessCounter,
             self::ENV_TEST_IS_FIRST_ON_CHANNEL => (int) $isFirstOnItsThread,
         ], CASE_UPPER);
+    }
+
+    /**
+     * @param array $variables
+     *
+     * @return array
+     */
+    public static function cleanEnvVariables(array $variables)
+    {
+        return array_filter(
+            $variables,
+            function ($key) {
+                return strpos($key, 'ENV_TEST_') !== 0;
+            },
+            ARRAY_FILTER_USE_KEY
+        );
     }
 }

--- a/tests/Process/ProcessFactoryTest.php
+++ b/tests/Process/ProcessFactoryTest.php
@@ -17,15 +17,15 @@ class ProcessFactoryTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals('bin'.DIRECTORY_SEPARATOR.'phpunit fileA', $process->getCommandLine());
         $this->assertEquals(
-            array_change_key_case($serverEnvs + $_ENV + [
+            $this->castValues(array_change_key_case($serverEnvs + $_ENV + [
                 'ENV_TEST_CHANNEL' => 2,
                 'ENV_TEST_CHANNEL_READABLE' => 'test_2',
                 'ENV_TEST_CHANNELS_NUMBER' => 10,
                 'ENV_TEST_ARGUMENT'=> 'fileA',
                 'ENV_TEST_INC_NUMBER' => 10,
                 'ENV_TEST_IS_FIRST_ON_CHANNEL' => 1,
-            ], CASE_UPPER),
-            $process->getenv()
+            ], CASE_UPPER)),
+            $this->castValues($process->getenv())
         );
     }
 
@@ -41,15 +41,15 @@ class ProcessFactoryTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals('execute', $process->getCommandLine());
         $this->assertEquals(
-            array_change_key_case($serverEnvs + $_ENV + [
+            $this->castValues(array_change_key_case($serverEnvs + $_ENV + [
                 'ENV_TEST_CHANNEL' => 2,
                 'ENV_TEST_CHANNEL_READABLE' => 'test_2',
                 'ENV_TEST_CHANNELS_NUMBER' => 11,
                 'ENV_TEST_ARGUMENT'=> 'fileA',
                 'ENV_TEST_INC_NUMBER' => 12,
                 'ENV_TEST_IS_FIRST_ON_CHANNEL' => 0,
-            ], CASE_UPPER),
-            $process->getenv()
+            ], CASE_UPPER)),
+            $this->castValues($process->getenv())
         );
     }
 
@@ -65,15 +65,34 @@ class ProcessFactoryTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals('execute 1 fileA 13', $process->getCommandLine());
         $this->assertEquals(
-            array_change_key_case($serverEnvs + $_ENV + [
+            $this->castValues(array_change_key_case($serverEnvs + $_ENV + [
                 'ENV_TEST_CHANNEL' => 1,
                 'ENV_TEST_CHANNEL_READABLE' => 'test_1',
                 'ENV_TEST_CHANNELS_NUMBER' => 12,
                 'ENV_TEST_ARGUMENT'=> 'fileA',
                 'ENV_TEST_INC_NUMBER' => 13,
                 'ENV_TEST_IS_FIRST_ON_CHANNEL' => 1,
-            ], CASE_UPPER),
-            $process->getenv()
+            ], CASE_UPPER)),
+            $this->castValues($process->getenv())
         );
+    }
+
+    /**
+     * Force casting of the env variable values to validate the difference of behavior
+     * between the versions Symfony Process '<3.2' and '>=3.2'.
+     *
+     * @param array $values
+     *
+     * @return array
+     */
+    private function castValues(array $values)
+    {
+        $envValues = array();
+
+        foreach ($values as $key => $value) {
+            $envValues[(binary) $key] = (binary) $value;
+        }
+
+        return $envValues;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #116
| License       | MIT
| Doc PR        | ~

To follow the discussion of the issue #116, I confirm that the problem stems from a different behavior between versions of the Symfony Process component. In the `< 3.2` versions, each value of the environment variables is converted to binary, whereas in the `>= 3.2` versions, the values are directly added without conversion. You can see the difference in the code:

- [Symfony Process v4.0](https://github.com/symfony/symfony/blob/4.0/src/Symfony/Component/Process/Process.php#L1083)
- [Symfony Process v3.4](https://github.com/symfony/symfony/blob/3.4/src/Symfony/Component/Process/Process.php#L1137)
- [Symfony Process v3.3](https://github.com/symfony/symfony/blob/3.3/src/Symfony/Component/Process/Process.php#L1133)
- [Symfony Process v3.2](https://github.com/symfony/symfony/blob/3.2/src/Symfony/Component/Process/Process.php#L1109)
- [Symfony Process v3.1](https://github.com/symfony/symfony/blob/3.1/src/Symfony/Component/Process/Process.php#L1091)
- [Symfony Process v3.0](https://github.com/symfony/symfony/blob/3.0/src/Symfony/Component/Process/Process.php#L1017)
- [Symfony Process v2.8](https://github.com/symfony/symfony/blob/2.8/src/Symfony/Component/Process/Process.php#L1020)
- [Symfony Process v2.7](https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/Process/Process.php#L1020)


So in our tests, you just have to convert each value into binaries for the 2 compared arrays. In this way we remove cast variations from the values of the Symfony Process component.