### PR TITLE
Find phpunit in vendor bin directory

### DIFF
--- a/src/Process/ProcessFactory.php
+++ b/src/Process/ProcessFactory.php
@@ -79,27 +79,35 @@ class ProcessFactory
 
     private static function getWindowsBinCmd()
     {
-        if (file_exists(getcwd().'/bin/phpunit')) {
-            $cmd = 'bin\phpunit {}';
-        } elseif (file_exists(getenv('APPDATA').'\Composer\vendor\bin\phpunit')) {
-            $cmd = '%APPDATA%\Composer\vendor\bin\phpunit {}';
-        } else {
-            $cmd = 'phpunit {}';
+        if (file_exists(getcwd().'/vendor/bin/phpunit')) {
+            return 'vendor\bin\phpunit {}';
         }
 
-        return $cmd;
+        if (file_exists(getcwd().'/bin/phpunit')) {
+            return 'bin\phpunit {}';
+        }
+
+        if (file_exists(getenv('APPDATA').'\Composer\vendor\bin\phpunit')) {
+            return '%APPDATA%\Composer\vendor\bin\phpunit {}';
+        }
+
+        return 'phpunit {}';
     }
 
     private static function getUnixBinCmd()
     {
-        if (file_exists(getcwd().'/bin/phpunit')) {
-            $cmd = 'bin/phpunit {}';
-        } elseif (file_exists(getenv('HOME').'/.composer/vendor/bin/phpunit')) {
-            $cmd = '~/.composer/vendor/bin/phpunit {}';
-        } else {
-            $cmd = 'phpunit {}';
+        if (file_exists(getcwd().'/vendor/bin/phpunit')) {
+            return 'vendor/bin/phpunit {}';
         }
 
-        return $cmd;
+        if (file_exists(getcwd().'/bin/phpunit')) {
+            return 'bin/phpunit {}';
+        }
+
+        if (file_exists(getenv('HOME').'/.composer/vendor/bin/phpunit')) {
+            return '~/.composer/vendor/bin/phpunit {}';
+        }
+
+        return 'phpunit {}';
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #99
| License       | MIT
| Doc PR        | ~

This PR allow to use Phpunit installed in the `./vendor/bin` directory in addition of the directories:

- `./bin`
- `~/.composer/vendor/bin` (unix)
- `%APPDATA%\Composer\vendor\bin` (windows)
- Or all Phpunit binary defined in the `PATH` variables