### PR TITLE
Fix renamed file loader in phpunit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,12 +31,15 @@ cache:
 before_script:
   - composer selfupdate
   - if [[ $TRAVIS_PHP_VERSION == 7.2 ]]; then
-      composer require "phpunit/phpunit:^6.1" --no-update;
+        composer require "phpunit/phpunit:^7.0" --no-update;
+    elif [[ $TRAVIS_PHP_VERSION == 7.1 ]]; then
+        composer require "phpunit/phpunit:^6.1" --no-update;
     else
-      composer require "phpunit/phpunit:^5.7" --no-update;
+        composer require "phpunit/phpunit:^5.7" --no-update;
     fi
   - composer update $PREFER_LOWEST
 
 script:
   - find tests/ -name "*Test.php" | php fastest -v
+  - ./fastest -x phpunit.xml.dist -v "vendor/phpunit/phpunit/phpunit {};"
   - bin/behat --config=adapters/Behat/behat.yml

--- a/src/Process/ProcessorCounter.php
+++ b/src/Process/ProcessorCounter.php
@@ -33,13 +33,13 @@ class ProcessorCounter
 
     private function readFromProcCPUInfo()
     {
-        if (PHP_OS === 'Darwin') {
+        if ($this->getOS() === 'Darwin') {
             $processors = system('/usr/sbin/sysctl -n hw.physicalcpu');
 
             if (false !== $processors && $processors) {
                 return $processors;
             }
-        } elseif (PHP_OS === 'Linux') {
+        } elseif ($this->getOS() === 'Linux') {
             $file = $this->procCPUInfo;
             if (is_file($file) && is_readable($file)) {
                 try {
@@ -59,5 +59,13 @@ class ProcessorCounter
         }
 
         return self::PROC_DEFAULT_NUMBER;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOS()
+    {
+        return PHP_OS;
     }
 }

--- a/src/Queue/CreateTestsQueueFromPhpUnitXML.php
+++ b/src/Queue/CreateTestsQueueFromPhpUnitXML.php
@@ -19,6 +19,13 @@ if (class_exists('\PHPUnit_Util_Fileloader')) {
     class_alias('\PHPUnit_Util_Fileloader', '\PHPUnit\Util\Fileloader');
 }
 
+/*
+ * Trigger autoload for possible file loader versions.
+ * This fixes the problem with PHP classes being case insensitive versus composer case sensitive autoloader.
+ */
+class_exists('\PHPUnit\Util\Fileloader');
+class_exists('\PHPUnit\Util\FileLoader');
+
 class CreateTestsQueueFromPhpUnitXML
 {
     public static function execute($xmlFile)
@@ -63,10 +70,6 @@ class CreateTestsQueueFromPhpUnitXML
     {
         $filename = isset($config['bootstrap']) ? $config['bootstrap'] : 'vendor/autoload.php';
 
-        if (class_exists('\PHPUnit\Util\Fileloader')) {
-            \PHPUnit\Util\Fileloader::checkAndLoad($filename);
-        } elseif (class_exists('\PHPUnit\Util\FileLoader')) {
-            \PHPUnit\Util\FileLoader::checkAndLoad($filename);
-        }
+        \PHPUnit\Util\FileLoader::checkAndLoad($filename);
     }
 }

--- a/src/Queue/CreateTestsQueueFromPhpUnitXML.php
+++ b/src/Queue/CreateTestsQueueFromPhpUnitXML.php
@@ -16,7 +16,11 @@ if (class_exists('\PHPUnit_Util_TestSuiteIterator')) {
 }
 
 if (class_exists('\PHPUnit_Util_Fileloader')) {
-    class_alias('\PHPUnit_Util_Fileloader', '\PHPUnit\Util\Fileloader');
+    class_alias('\PHPUnit_Util_Fileloader', '\PHPUnit\Util\FileLoader');
+}
+
+if (class_exists('\PHPUnit\Util\Fileloader')) {
+    class_alias('\PHPUnit\Util\Fileloader', '\PHPUnit\Util\FileLoader');
 }
 
 class CreateTestsQueueFromPhpUnitXML
@@ -61,6 +65,6 @@ class CreateTestsQueueFromPhpUnitXML
     {
         $filename = isset($config['bootstrap']) ? $config['bootstrap'] : 'vendor/autoload.php';
 
-        \PHPUnit\Util\Fileloader::checkAndLoad($filename);
+        \PHPUnit\Util\FileLoader::checkAndLoad($filename);
     }
 }

--- a/src/Queue/CreateTestsQueueFromPhpUnitXML.php
+++ b/src/Queue/CreateTestsQueueFromPhpUnitXML.php
@@ -16,11 +16,7 @@ if (class_exists('\PHPUnit_Util_TestSuiteIterator')) {
 }
 
 if (class_exists('\PHPUnit_Util_Fileloader')) {
-    class_alias('\PHPUnit_Util_Fileloader', '\PHPUnit\Util\FileLoader');
-}
-
-if (class_exists('\PHPUnit\Util\Fileloader')) {
-    class_alias('\PHPUnit\Util\Fileloader', '\PHPUnit\Util\FileLoader');
+    class_alias('\PHPUnit_Util_Fileloader', '\PHPUnit\Util\Fileloader');
 }
 
 class CreateTestsQueueFromPhpUnitXML
@@ -36,8 +32,10 @@ class CreateTestsQueueFromPhpUnitXML
         return $testSuites;
     }
 
-    private static function processTestSuite(TestsQueue $testSuites, \PHPUnit\Framework\TestSuiteIterator $testSuiteIterator)
-    {
+    private static function processTestSuite(
+        TestsQueue $testSuites,
+        \PHPUnit\Framework\TestSuiteIterator $testSuiteIterator
+    ) {
         foreach ($testSuiteIterator as $testSuite) {
             self::addTestFile($testSuites, $testSuite);
 
@@ -65,6 +63,10 @@ class CreateTestsQueueFromPhpUnitXML
     {
         $filename = isset($config['bootstrap']) ? $config['bootstrap'] : 'vendor/autoload.php';
 
-        \PHPUnit\Util\FileLoader::checkAndLoad($filename);
+        if (class_exists('\PHPUnit\Util\Fileloader')) {
+            \PHPUnit\Util\Fileloader::checkAndLoad($filename);
+        } elseif (class_exists('\PHPUnit\Util\FileLoader')) {
+            \PHPUnit\Util\FileLoader::checkAndLoad($filename);
+        }
     }
 }

--- a/tests/Process/ProcessorCounterTest.php
+++ b/tests/Process/ProcessorCounterTest.php
@@ -9,8 +9,15 @@ class ProcessorCounterTest extends \PHPUnit\Framework\TestCase
      */
     public function shouldCountTheNumberOfProcessorInLinux()
     {
-        $processorCount = new ProcessorCounter(__DIR__.'/Fixture/proc_cpuinfo');
+        $processorCountMock = $this->getMockBuilder(ProcessorCounter::class)
+                                   ->setMethods(['getOS'])
+                                   ->setConstructorArgs([__DIR__.'/Fixture/proc_cpuinfo'])
+                                   ->getMock();
 
-        $this->assertEquals(4, $processorCount->execute());
+        $processorCountMock->expects($this->any())
+                           ->method('getOS')
+                           ->will($this->returnValue('Linux'));
+
+        $this->assertEquals(4, $processorCountMock->execute());
     }
 }


### PR DESCRIPTION
It was renamed from `PHPUnit\Util\Fileloader` to `PHPUnit\Util\FileLoader` in https://github.com/sebastianbergmann/phpunit/commit/3a9494be34135e5d42964ec7f5f17605e736a2c7#diff-7862e6eec2d5923e62d57728b79a0480