### PR TITLE
Bumped PHP min version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.1
   - 7.2
   - 7.3
 

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
         "symfony/console": "^2.8|^3.4|^4.0",
         "symfony/stopwatch": "^2.8|^3.4|^4.0",
         "symfony/process": "^2.8|^3.4|^4.0",


### PR DESCRIPTION
In two months PHP 7.1 will go in "end of life" status https://www.php.net/supported-versions.php
As no sooner release seems to be planned and I really don't know when I will have time again to check this project, I've decided to bump PHP version.