### PR TITLE
Bumped symfony version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
     ],
     "require": {
         "php": "^7.2",
-        "symfony/console": "^2.8|^3.4|^4.0",
-        "symfony/stopwatch": "^2.8|^3.4|^4.0",
-        "symfony/process": "^2.8|^3.4|^4.0",
+        "symfony/console": "^3.4|^4.2",
+        "symfony/stopwatch": "^3.4|^4.2",
+        "symfony/process": "^3.4|^4.2",
         "doctrine/collections": "^1.2"
     },
     "require-dev": {


### PR DESCRIPTION
Symfony 2.8 will be "end of life" in a month https://symfony.com/roadmap/2.8
Moreover I've bumped version 4 minor version to 2