### PR TITLE
Test improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin
 composer.lock
 phpunit.xml
 vendor
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 php:
   - 7.2
   - 7.3
-  - 7.4snapshot
+  - 7.4
 
 env:
   matrix:
@@ -21,5 +21,5 @@ before_script:
 
 script:
   - find tests/ -name "*Test.php" | php fastest -v
-  - ./fastest -x phpunit.xml.dist -v "vendor/phpunit/phpunit/phpunit {};"
+  - ./fastest -x phpunit.xml.dist -v "bin/phpunit {};"
   - bin/behat --config=adapters/Behat/behat.yml

--- a/tests/Environment/FastestEnvironmentTest.php
+++ b/tests/Environment/FastestEnvironmentTest.php
@@ -3,10 +3,11 @@
 namespace Liuggio\Fastest\Environment;
 
 use Liuggio\Fastest\Process\EnvCommandCreator;
+use PHPUnit\Framework\TestCase;
 
-class FastestEnvironmentTest extends \PHPUnit\Framework\TestCase
+class FastestEnvironmentTest extends TestCase
 {
-    public function setup(): void
+    protected function setUp(): void
     {
         $envName = EnvCommandCreator::ENV_TEST_CHANNEL_READABLE;
         putenv("$envName=");

--- a/tests/Process/ProcessFactoryTest.php
+++ b/tests/Process/ProcessFactoryTest.php
@@ -2,7 +2,9 @@
 
 namespace Liuggio\Fastest\Process;
 
-class ProcessFactoryTest extends \PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class ProcessFactoryTest extends TestCase
 {
     /**
      * @test

--- a/tests/Process/ProcessesManagerTest.php
+++ b/tests/Process/ProcessesManagerTest.php
@@ -4,8 +4,9 @@ namespace Liuggio\Fastest\Process;
 
 use Liuggio\Fastest\Queue\TestSuite;
 use Symfony\Component\Process\Process;
+use PHPUnit\Framework\TestCase;
 
-class ProcessesManagerTest extends \PHPUnit\Framework\TestCase
+class ProcessesManagerTest extends TestCase
 {
     /**
      * @test

--- a/tests/Process/ProcessesTest.php
+++ b/tests/Process/ProcessesTest.php
@@ -3,8 +3,9 @@
 namespace Liuggio\Fastest\Process;
 
 use Symfony\Component\Process\Process;
+use PHPUnit\Framework\TestCase;
 
-class ProcessesTest extends \PHPUnit\Framework\TestCase
+class ProcessesTest extends TestCase
 {
     /**
      * @test

--- a/tests/Process/ProcessorCounterTest.php
+++ b/tests/Process/ProcessorCounterTest.php
@@ -2,7 +2,9 @@
 
 namespace Liuggio\Fastest\Process;
 
-class ProcessorCounterTest extends \PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class ProcessorCounterTest extends TestCase
 {
     /**
      * @test

--- a/tests/Queue/CreateTestsQueueFromPhpUnitXMLTest.php
+++ b/tests/Queue/CreateTestsQueueFromPhpUnitXMLTest.php
@@ -2,7 +2,9 @@
 
 namespace Liuggio\Fastest\Queue;
 
-class CreateTestsQueueFromPhpUnitXMLTest extends \PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class CreateTestsQueueFromPhpUnitXMLTest extends TestCase
 {
     /**
      * @test

--- a/tests/Queue/CreateTestsQueueFromSTDINTest.php
+++ b/tests/Queue/CreateTestsQueueFromSTDINTest.php
@@ -2,7 +2,9 @@
 
 namespace Liuggio\Fastest\Queue;
 
-class CreateTestsQueueFromSTDINTest extends \PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class CreateTestsQueueFromSTDINTest extends TestCase
 {
     /**
      * @test

--- a/tests/Queue/Infrastructure/InMemoryQueueFactoryTest.php
+++ b/tests/Queue/Infrastructure/InMemoryQueueFactoryTest.php
@@ -2,7 +2,10 @@
 
 namespace Liuggio\Fastest\Queue\Infrastructure;
 
-class InMemoryQueueFactoryTest extends \PHPUnit\Framework\TestCase
+use Liuggio\Fastest\Queue\Infrastructure\InMemoryQueue;
+use PHPUnit\Framework\TestCase;
+
+class InMemoryQueueFactoryTest extends TestCase
 {
     /**
      * @test
@@ -13,6 +16,6 @@ class InMemoryQueueFactoryTest extends \PHPUnit\Framework\TestCase
 
         $queue = $msqQueueFactory->create();
 
-        $this->assertInstanceOf('\Liuggio\Fastest\Queue\Infrastructure\InMemoryQueue', $queue);
+        $this->assertInstanceOf(InMemoryQueue::class, $queue);
     }
 }

--- a/tests/Queue/ReadFromInputAndPushIntoTheQueueTest.php
+++ b/tests/Queue/ReadFromInputAndPushIntoTheQueueTest.php
@@ -2,7 +2,9 @@
 
 namespace Liuggio\Fastest\Queue;
 
-class ReadFromInputAndPushIntoTheQueueTest extends \PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class ReadFromInputAndPushIntoTheQueueTest extends TestCase
 {
     /**
      * @test


### PR DESCRIPTION
# Changed log
- Remove `php7.4-snapshot` version test and using `php-7.4` version instead on Travis CI build.
- According to the [PHPUnit fixtures reference](https://phpunit.de/manual/7.0/en/fixtures.html), the `setUp` method is `protected`, not `public`.