### PR TITLE
Added compatibility with Symfony 5 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
     ],
     "require": {
         "php": "^7.2",
-        "symfony/console": "^3.4|^4.2",
-        "symfony/stopwatch": "^3.4|^4.2",
-        "symfony/process": "^3.4|^4.2",
+        "symfony/console": "^3.4|^4.2|^5.0",
+        "symfony/stopwatch": "^3.4|^4.2|^5.0",
+        "symfony/process": "^3.4|^4.2|^5.0",
         "doctrine/collections": "^1.2"
     },
     "require-dev": {

--- a/src/Process/ProcessFactory.php
+++ b/src/Process/ProcessFactory.php
@@ -52,7 +52,12 @@ class ProcessFactory
 
     private function createProcess($executeCommand, $arrayEnv)
     {
-        $process = new Process($executeCommand, null, $arrayEnv);
+        // compatibility to SF 4 & 5
+        if (method_exists(Process::class, 'fromShellCommandline')) {
+            $process = Process::fromShellCommandline($executeCommand, null, $arrayEnv);
+        } else {
+            $process = new Process($executeCommand, null, $arrayEnv);
+        }
 
         $process->setTimeout(null);
         // compatibility to SF 2.2

--- a/tests/Process/ProcessesManagerTest.php
+++ b/tests/Process/ProcessesManagerTest.php
@@ -22,7 +22,7 @@ class ProcessesManagerTest extends TestCase
         $factory->expects($this->once())
             ->method('createAProcessForACustomCommand')
             ->with($this->anything(), $this->equalTo(1), $this->equalTo(1), $this->equalTo(true))
-            ->willReturn(new Process('echo '.rand(), sys_get_temp_dir()));
+            ->willReturn(new Process(['echo', rand()], sys_get_temp_dir()));
 
         $manager = new ProcessesManager($factory, 1, 'echo "ciao"');
 
@@ -57,7 +57,7 @@ class ProcessesManagerTest extends TestCase
         $factory->expects($this->exactly(1))
             ->method('createAProcess')
             ->with($this->anything(), $this->equalTo(1), $this->equalTo(1), $this->equalTo(true))
-            ->willReturn(new Process('echo ', rand()));
+            ->willReturn(new Process(['echo', rand()]));
 
         $manager = new ProcessesManager($factory, 1);
 
@@ -107,7 +107,7 @@ class ProcessesManagerTest extends TestCase
             $factory->expects($this->at($at))
                 ->method('createAProcess')
                 ->with($this->anything(), $this->equalTo($expectation[0]), $this->equalTo($expectation[1]), $this->equalTo($expectation[2]))
-                ->willReturn(new Process('echo ', rand()));
+                ->willReturn(new Process(['echo', rand()]));
         }
 
         $manager = new ProcessesManager($factory, 1);


### PR DESCRIPTION
Since #143 is not really moving forward I'm making new pull request. I've aligned the code to suggestions from @DonCallisto. Since it is no longer possible to mock static methods in phpunit (ref. https://github.com/sebastianbergmann/phpunit-documentation/issues/77) I didn't want to go into the route of using another Mock framework. It would be just better to rely on Travis so it tests using different Symfony versions. I think this is the case now so it's covered.

I've also fixed `ProcessManagerTest` by changing all commands to arrays since it's supported in all `symfony/process` versions.