### PR TITLE
Use MongoDB\Client as adapter base connection

### DIFF
--- a/adapters/Doctrine/MongoDB/Connection.php
+++ b/adapters/Doctrine/MongoDB/Connection.php
@@ -2,16 +2,16 @@
 
 namespace Liuggio\Fastest\Doctrine\MongoDB;
 
-use Doctrine\MongoDB\Connection as BaseConnection;
+use MongoDB\Client as BaseConnection;
 use Liuggio\Fastest\Process\EnvCommandCreator;
 
 class Connection extends BaseConnection
 {
-    public function selectDatabase($name)
+    public function selectDatabase($databaseName, array $options = [])
     {
-        $name = $this->getDbNameFromEnv($name);
+        $databaseName = $this->getDbNameFromEnv($databaseName);
 
-        return parent::selectDatabase($name);
+        return parent::selectDatabase($databaseName, $options);
     }
 
     private function getDbNameFromEnv($dbName)


### PR DESCRIPTION
MongoDB adapter use Doctrine\MongoDB\Connection as the base connection class.

This class belongs to the doctrine/mongodb project that is discontinued.

This PR updates the MongoDB adapter to use the MongoDB\Client class as base connection in order to use it with the new doctrine/mongodb-odm project