### PR TITLE
Add no-progress option

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ Options:
  --preserve-order (-o) Queue is randomized by default, with this option the queue is read preserving the order.
  --rerun-failed (-r)   Re-run failed test with before command if exists.
  --no-errors-summary   Do not display all errors after the test run. Useful with --vv because it already displays errors immediately after they happen.
+ --no-progress         Do not display progress bar when running.
  --help (-h)           Display this help message.
  --quiet (-q)          Do not output any message.
  --verbose (-v|vv|vvv) Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

--- a/src/UI/NoProgressRenderer.php
+++ b/src/UI/NoProgressRenderer.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Liuggio\Fastest\UI;
+
+use Liuggio\Fastest\Process\Processes;
+use Liuggio\Fastest\Queue\QueueInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class NoProgressRenderer implements RendererInterface
+{
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    /**
+     * @var bool
+     */
+    private $errorsSummary;
+
+    /**
+     * @param bool $errorsSummary Whether to display errors summary in the footer
+     * @param OutputInterface $output
+     */
+    public function __construct(bool $errorsSummary, OutputInterface $output)
+    {
+        $this->errorsSummary = $errorsSummary;
+        $this->output = $output;
+    }
+
+    public function renderHeader(QueueInterface $queue): void
+    {
+    }
+
+    public function renderBody(QueueInterface $queue, Processes $processes): int
+    {
+        return $processes->countErrors();
+    }
+
+    public function renderFooter(QueueInterface $queue, Processes $processes): void
+    {
+        $this->output->writeln('');
+        if ($this->errorsSummary) {
+            $this->output->writeln($processes->getErrorOutput());
+        }
+
+        $out = '    <info>✔</info> You are great!';
+        if (!$processes->isSuccessful()) {
+            $out = '    <error>✘ ehm broken tests...</error>';
+        }
+
+        $this->output->writeln(PHP_EOL . $out);
+    }
+}


### PR DESCRIPTION
This PR adds an option to surpress the progress bar when running fastest. The progress bar adds clutter when used in CI/CD for example, this option helps to avoid that.