### PR TITLE
Allow doctrine/collections:^2.0 as alternative dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "symfony/console": "^4.4|^5.0|^6.0",
         "symfony/stopwatch": "^4.4|^5.0|^6.0",
         "symfony/process": "^4.4.35|^5.0|^6.0",
-        "doctrine/collections": "^1.2"
+        "doctrine/collections": "^1.2|^2.0"
     },
     "require-dev": {
         "behat/behat": "^3.6",


### PR DESCRIPTION
Given [this](https://github.com/doctrine/collections/blob/2.1.x/UPGRADE.md#bc-breaking-changes), seems no harm to include major version 2 as an alternative dependency.

I only noticed this as one of my projects wanted to upgrade to `doctrine/collections:^2.0` but couldn't because `liuggio/fastest` depends exclusively on major version 1.