### PR TITLE
Doctrine collections compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "symfony/console": "^4.4|^5.0|^6.0",
         "symfony/stopwatch": "^4.4|^5.0|^6.0",
         "symfony/process": "^4.4.35|^5.0|^6.0",
-        "doctrine/collections": "^1.2|^2.0"
+        "doctrine/collections": "^1.2|^2.0",
+        "symfony/deprecation-contracts": "^2.1|^3"
     },
     "require-dev": {
         "behat/behat": "^3.6",

--- a/src/Queue/TestsQueue.php
+++ b/src/Queue/TestsQueue.php
@@ -54,6 +54,12 @@ class TestsQueue extends ArrayCollection
         }
 
         parent::add($value);
+
+        trigger_deprecation(
+            'liuggio/fastest', 
+            '1.10', 
+            'The return value of Liuggio\Fastest\Queue\TestsQueue:add will change to void in v2 of the package'
+        );
         
         return true;
     }

--- a/src/Queue/TestsQueue.php
+++ b/src/Queue/TestsQueue.php
@@ -53,7 +53,9 @@ class TestsQueue extends ArrayCollection
             $value = new TestSuite($value);
         }
 
-        return parent::add($value);
+        parent::add($value);
+        
+        return true;
     }
 
     /**


### PR DESCRIPTION
Follow-up to the discussion in https://github.com/liuggio/fastest/pull/187

I've decided to use https://github.com/symfony/deprecation-contracts , because it provides a unified way to do deprecations. Also it's already a transitive dependency of this package:
```
symfony/config               v6.2.7     requires symfony/deprecation-contracts (^2.1|^3) 
symfony/console              v6.2.7     requires symfony/deprecation-contracts (^2.1|^3) 
symfony/dependency-injection v6.2.7     requires symfony/deprecation-contracts (^2.1|^3) 
```
