### PR TITLE
Upgrade dependencies to symfony/* 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "symfony/console": "^4.4|^5.0|^6.0",
-        "symfony/stopwatch": "^4.4|^5.0|^6.0",
-        "symfony/process": "^4.4.35|^5.0|^6.0",
+        "symfony/console": "^5.4|^6.0|^7.0",
+        "symfony/stopwatch": "^5.4|^6.0|^7.0",
+        "symfony/process": "^5.4|^6.0|^7.0",
         "doctrine/collections": "^1.2|^2.0",
         "symfony/deprecation-contracts": "^2.1|^3"
     },


### PR DESCRIPTION
I upgrade dependencies to symfony/* 7.0
 
 "symfony/console": "^4.4|^5.0|^6.0|^7.0",
  "symfony/stopwatch": "^4.4|^5.0|^6.0|^7.0",
  "symfony/process": "^4.4.35|^5.0|^6.0|^7.0",