### PR TITLE
Fix "Array to string conversion" for Symfony 7.4+ compatibility

### DIFF
--- a/src/Process/EnvCommandCreator.php
+++ b/src/Process/EnvCommandCreator.php
@@ -44,11 +44,50 @@ class EnvCommandCreator
             }
 
             if (!is_array($value)) {
-                $res[$key] = $value;
-                $mergedArgs[strtolower($key)] = true;
+                $formattedValue = self::formatValueForEnv($value);
+                if (null !== $formattedValue) {
+                    $res[$key] = $value;
+                    $mergedArgs[strtolower($key)] = true;
+                }
+            } else {
+                self::decomposeRecursively($key, $value, $res, $mergedArgs);
             }
         }
 
         return $res;
+    }
+
+    /**
+     * @param array<mixed> $source
+     * @param array<mixed> $globalArray
+     * @param array<mixed> $mergedArgs
+     */
+    public static function decomposeRecursively(string $mainKey, array $source, array &$globalArray, array &$mergedArgs): void
+    {
+        foreach ($source as $childKey => $value) {
+            $newKey = $mainKey . '_' . $childKey;
+            if (is_array($value)) {
+                self::decomposeRecursively($newKey, $value, $globalArray, $mergedArgs);
+            } elseif (!array_key_exists($newKey, $globalArray)) {
+                $formattedValue = self::formatValueForEnv($value);
+                if (null !== $formattedValue) {
+                    $globalArray[$newKey] = $formattedValue;
+                    $mergedArgs[strtolower($newKey)] = true;
+                }
+            }
+        }
+    }
+
+    public static function formatValueForEnv(mixed $value): ?string
+    {
+        if (is_scalar($value)) {
+            return (string) $value;
+        }
+
+        if (is_object($value) && method_exists($value, '__toString')) {
+            return (string) $value;
+        }
+
+        return null;
     }
 }

--- a/tests/Process/ProcessFactoryTest.php
+++ b/tests/Process/ProcessFactoryTest.php
@@ -26,7 +26,7 @@ class ProcessFactoryTest extends TestCase
                 'ENV_TEST_ARGUMENT' => 'fileA',
                 'ENV_TEST_INC_NUMBER' => 10,
                 'ENV_TEST_IS_FIRST_ON_CHANNEL' => 1,
-            ] + $this->getServerWithoutArgv() + $_ENV,
+            ] + $this->getServerWithDecomposeArgv() + $_ENV,
             $process->getenv()
         );
     }
@@ -87,7 +87,7 @@ class ProcessFactoryTest extends TestCase
                 'ENV_TEST_ARGUMENT' => 'fileA',
                 'ENV_TEST_INC_NUMBER' => 12,
                 'ENV_TEST_IS_FIRST_ON_CHANNEL' => 0,
-            ] + $this->getServerWithoutArgv() + $_ENV,
+            ] + $this->getServerWithDecomposeArgv() + $_ENV,
             $process->getenv()
         );
     }
@@ -109,7 +109,7 @@ class ProcessFactoryTest extends TestCase
                 'ENV_TEST_ARGUMENT' => 'fileA',
                 'ENV_TEST_INC_NUMBER' => 13,
                 'ENV_TEST_IS_FIRST_ON_CHANNEL' => 1,
-            ] + $this->getServerWithoutArgv() + $_ENV,
+            ] + $this->getServerWithDecomposeArgv() + $_ENV,
             $process->getenv()
         );
     }

--- a/tests/Trait/ServerDataTrait.php
+++ b/tests/Trait/ServerDataTrait.php
@@ -4,17 +4,26 @@ declare(strict_types=1);
 
 namespace Liuggio\Fastest\Trait;
 
+use Liuggio\Fastest\Process\EnvCommandCreator;
+
 trait ServerDataTrait
 {
     /**
      * @return array<scalar>
      */
-    protected function getServerWithoutArgv(): array
+    protected function getServerWithDecomposeArgv(): array
     {
         $server = $_SERVER;
-        if (array_key_exists('argv', $server)) {
+
+        if (isset($server['argv']) && is_array($server['argv'])) {
+            $mergedArgs = array_fill_keys(
+                array_map('strtolower', array_keys($server)),
+                true
+            );
+            EnvCommandCreator::decomposeRecursively('argv', $server['argv'], $server, $mergedArgs);
             unset($server['argv']);
         }
+
         return $server;
     }
 }


### PR DESCRIPTION
### Description

This PR fixes a `Warning: Array to string conversion` that occurs when using `liuggio/fastest` with Symfony 7.4 or higher.

**The issue:**
Since Symfony 7.4, the Symfony Runtime component exposes new entries in `$_SERVER`, specifically `APP_RUNTIME_OPTIONS`. This entry is an **array**.
When `EnvCommandCreator::execute` merges `$_SERVER` into the environment variables for the subprocess, it includes this array. Later, when `Symfony\Component\Process` tries to start the process, it iterates over these variables and fails because it attempts to concatenate an array as a string:

```php
// Symfony\Component\Process\Process.php
$envPairs[] = $k.'='.$v; // Error here if $v is an array

```

**The fix:**
I updated `EnvCommandCreator` to filter out any values that are arrays. Environment variables should fundamentally be strings; passing an array through the environment is not supported by the underlying OS/process components anyway.

### Changes

* Modified `Liuggio\Fastest\Process\EnvCommandCreator::execute` to skip elements where the value is an `array`.