### PR TITLE
New merge parameters

### DIFF
--- a/src/Process/ProcessFactory.php
+++ b/src/Process/ProcessFactory.php
@@ -81,6 +81,11 @@ class ProcessFactory
     private function replaceParameters(string $cmd, string $suite, int $processNumber, int $currentProcessCounter): string
     {
         $commandToExecute = str_replace('{}', $suite, $cmd);
+
+        $commandToExecute = str_replace('{filename}', $suite, $commandToExecute);
+        $cleanFilename = trim(preg_replace('/[^a-z0-9_-]/i', '_', $suite));
+        $commandToExecute = str_replace('{clean_filename}', $cleanFilename, $commandToExecute);
+
         $commandToExecute = str_replace('{p}', (string) $processNumber, $commandToExecute);
         $commandToExecute = str_replace('{n}', (string) $currentProcessCounter, $commandToExecute);
 


### PR DESCRIPTION
When testing I had an odd error that meant I would get "no scenarios" in the output - while there maybe other ways around it I created a new merge parameter to output the "clean" file so that I could name them `--out=my_output_file_{clean_filename}_p{p}_n{n}` created so this would clearly indicate which scenario was the problem.  The problem was actually that when I called `bin/behat --tags=@tag --list-scenarios | vendor/liuggio/fastest/fastest "bin/behat {}" ` this _missed_ the tags in each separate call which then used the default suite tags from `behat.yml` and therefore couldn't find the scenario.

Also found it confusing to have a merge tag with no label so I suggest that is updated inline with the new merge tag.