### PR TITLE
Add dot/format progress and re-run error summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ If you want to use it with phpunit you may want to install phpunit/phpunit as de
 
 ```
 Usage:
- fastest [-p|--process="..."] [-b|--before="..."] [-x|--xml="..."] [-o|--preserve-order] [--no-errors-summary] [execute]
+ fastest [-p|--process="..."] [-b|--before="..."] [-x|--xml="..."] [-o|--preserve-order] [--show-rerun-failed] [--no-errors-summary] [--dot-progress] [execute]
 
 Arguments:
  execute               Optional command to execute.
@@ -303,7 +303,9 @@ Options:
  --xml (-x)            Read input from a phpunit xml file from the '<testsuites>' collection. Note: it is not used for consuming.
  --preserve-order (-o) Queue is randomized by default, with this option the queue is read preserving the order.
  --rerun-failed (-r)   Re-run failed test with before command if exists.
+ --show-rerun-failed   Display the errors summary for the failed test re-run even when --no-errors-summary is used.
  --no-errors-summary   Do not display all errors after the test run. Useful with --vv because it already displays errors immediately after they happen.
+ --dot-progress        Display dot progress instead of the progress bar.
  --no-progress         Do not display progress bar when running.
  --help (-h)           Display this help message.
  --quiet (-q)          Do not output any message.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,9 +3,11 @@
 <phpunit bootstrap="vendor/autoload.php" colors="true" backupGlobals="true">
     <testsuites>
         <testsuite name="Fastest Test Suite">
+            <directory>tests/Command/</directory>
             <directory>tests/Queue/</directory>
             <directory>tests/Process/</directory>
             <directory>tests/Environment/</directory>
+            <directory>tests/UI/</directory>
         </testsuite>
     </testsuites>
 

--- a/src/Command/ParallelCommand.php
+++ b/src/Command/ParallelCommand.php
@@ -5,10 +5,12 @@ namespace Liuggio\Fastest\Command;
 use Liuggio\Fastest\Process\Processes;
 use Liuggio\Fastest\Queue\QueueInterface;
 use Liuggio\Fastest\Queue\TestsQueue;
+use Liuggio\Fastest\UI\DotProgressRenderer;
+use Liuggio\Fastest\UI\NoProgressRenderer;
 use Liuggio\Fastest\UI\ProgressBarRenderer;
+use Liuggio\Fastest\UI\RendererInterface;
 use Liuggio\Fastest\UI\VerboseRenderer;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -18,7 +20,6 @@ use Liuggio\Fastest\Process\ProcessFactory;
 use Liuggio\Fastest\Process\ProcessorCounter;
 use Liuggio\Fastest\Queue\Infrastructure\InMemoryQueueFactory;
 use Liuggio\Fastest\Queue\ReadFromInputAndPushIntoTheQueue;
-use Liuggio\Fastest\UI\NoProgressRenderer;
 use Symfony\Component\Stopwatch\Stopwatch;
 
 class ParallelCommand extends Command
@@ -29,8 +30,10 @@ class ParallelCommand extends Command
     private const XML_OPTION = 'xml';
     private const PRESERVE_ORDER_OPTION = 'preserve-order';
     private const RERUN_FAILED_OPTION = 'rerun-failed';
+    private const SHOW_RERUN_FAILED_OPTION = 'show-rerun-failed';
     private const NO_ERRORS_SUMMARY_OPTION = 'no-errors-summary';
     private const NO_PROGRESS_OPTION = 'no-progress';
+    private const DOT_PROGRESS_OPTION = 'dot-progress';
 
     protected function configure(): void
     {
@@ -73,6 +76,12 @@ class ParallelCommand extends Command
                 'Re-run failed test with before command if exists.'
             )
             ->addOption(
+                self::SHOW_RERUN_FAILED_OPTION,
+                null,
+                InputOption::VALUE_NONE,
+                'Display the errors summary for the failed test re-run even when --no-errors-summary is used.'
+            )
+            ->addOption(
                 self::NO_ERRORS_SUMMARY_OPTION,
                 null,
                 InputOption::VALUE_NONE,
@@ -83,6 +92,12 @@ class ParallelCommand extends Command
                 null,
                 InputOption::VALUE_NONE,
                 'Do not display progress',
+            )
+            ->addOption(
+                self::DOT_PROGRESS_OPTION,
+                null,
+                InputOption::VALUE_NONE,
+                'Display dot progress instead of the progress bar.',
             )
         ;
     }
@@ -133,6 +148,12 @@ class ParallelCommand extends Command
         }
         $noProgressOption = (bool) $noProgressOption;
 
+        $dotProgressOption = $input->getOption(self::DOT_PROGRESS_OPTION);
+        if (!is_bool($dotProgressOption) && null !== $dotProgressOption) {
+            throw new \Exception(sprintf('%s should not have any value', self::DOT_PROGRESS_OPTION));
+        }
+        $dotProgressOption = (bool) $dotProgressOption;
+
         $processManager = new ProcessesManager($maxNumberOfParallelProc, $processFactory, $beforeOption);
 
         // header
@@ -141,7 +162,7 @@ class ParallelCommand extends Command
         $output->writeln('- Will be consumed by <fg=white;bg=blue>'.$maxNumberOfParallelProc.'</> parallel Processes.');
 
         // loop
-        $processes = $this->doExecute($input, $output, $queue, $processManager, $noProgressOption);
+        $processes = $this->doExecute($input, $output, $queue, $processManager, $noProgressOption, $dotProgressOption);
 
         $event = $stopWatch->stop('execute');
         $output->writeln(sprintf(
@@ -151,7 +172,15 @@ class ParallelCommand extends Command
         ));
 
         if ($input->getOption(self::RERUN_FAILED_OPTION)) {
-            $processes = $this->executeBeforeCommand($queue, $processes, $input, $output, $processManager, $noProgressOption);
+            $processes = $this->executeBeforeCommand(
+                $queue,
+                $processes,
+                $input,
+                $output,
+                $processManager,
+                $noProgressOption,
+                $dotProgressOption
+            );
         }
 
         return $processes->getExitCode();
@@ -173,17 +202,19 @@ class ParallelCommand extends Command
         OutputInterface $output,
         QueueInterface $queue,
         ProcessesManager $processManager,
-        bool $noProgressOption
+        bool $noProgressOption,
+        bool $dotProgressOption,
+        ?bool $errorsSummary = null
     ): Processes {
         $processes = null;
-
-        if ($noProgressOption) {
-            $progressBar = new NoProgressRenderer($this->hasErrorSummary($input), $output);
-        } elseif ($this->isVerbose($output)) {
-            $progressBar = new VerboseRenderer($queue->count(), $this->hasErrorSummary($input), $output);
-        } else {
-            $progressBar = new ProgressBarRenderer($queue->count(), $this->hasErrorSummary($input), $output);
-        }
+        $progressBar = $this->createRenderer(
+            $input,
+            $output,
+            $queue,
+            $noProgressOption,
+            $dotProgressOption,
+            $errorsSummary
+        );
 
         $progressBar->renderHeader($queue);
 
@@ -213,19 +244,58 @@ class ParallelCommand extends Command
         return !$input->getOption(self::NO_ERRORS_SUMMARY_OPTION);
     }
 
+    protected function hasRerunErrorSummary(InputInterface $input): bool
+    {
+        return $this->hasErrorSummary($input) || (bool) $input->getOption(self::SHOW_RERUN_FAILED_OPTION);
+    }
+
+    protected function createRenderer(
+        InputInterface $input,
+        OutputInterface $output,
+        QueueInterface $queue,
+        bool $noProgressOption,
+        bool $dotProgressOption,
+        ?bool $errorsSummary = null
+    ): RendererInterface {
+        $errorsSummary = null === $errorsSummary ? $this->hasErrorSummary($input) : $errorsSummary;
+
+        if ($noProgressOption) {
+            return new NoProgressRenderer($errorsSummary, $output);
+        }
+
+        if ($dotProgressOption) {
+            return new DotProgressRenderer($queue->count(), $errorsSummary, $output);
+        }
+
+        if ($this->isVerbose($output)) {
+            return new VerboseRenderer($queue->count(), $errorsSummary, $output);
+        }
+
+        return new ProgressBarRenderer($queue->count(), $errorsSummary, $output);
+    }
+
     private function executeBeforeCommand(
         QueueInterface $queue,
         Processes $processes,
         InputInterface $input,
         OutputInterface $output,
         ProcessesManager $processManager,
-        bool $noProgressOption
+        bool $noProgressOption,
+        bool $dotProgressOption
     ): Processes {
         if (!$processes->isSuccessful()) {
             $array = $processes->getErrorOutput();
             $output->writeln(sprintf('Re-Running [%d] elements', count($array)));
             $queue->push(new TestsQueue(array_keys($array)));
-            $processes = $this->doExecute($input, $output, $queue, $processManager, $noProgressOption);
+            $processes = $this->doExecute(
+                $input,
+                $output,
+                $queue,
+                $processManager,
+                $noProgressOption,
+                $dotProgressOption,
+                $this->hasRerunErrorSummary($input)
+            );
         }
 
         return $processes;

--- a/src/Process/Processes.php
+++ b/src/Process/Processes.php
@@ -238,7 +238,7 @@ class Processes
 
         if (!$process->isSuccessful()) {
             ++$this->errorCounter;
-            $this->errorBuffer[$suite] = sprintf('[%s] %s', $number, $suite);
+            $this->errorBuffer[$suite] = sprintf('[%s] %s', $number, $suite).PHP_EOL;
             $this->errorBuffer[$suite] .= $process->getOutput();
             $this->errorBuffer[$suite] .= $process->getErrorOutput();
         }

--- a/src/Process/Processes.php
+++ b/src/Process/Processes.php
@@ -239,9 +239,7 @@ class Processes
 
         if (!$process->isSuccessful()) {
             ++$this->errorCounter;
-            $this->errorBuffer[$suite] = sprintf('[%d] %s', $processorNumber, $suite).PHP_EOL;
-            $this->errorBuffer[$suite] .= $process->getOutput();
-            $this->errorBuffer[$suite] .= $process->getErrorOutput();
+            $this->errorBuffer[$suite] = $this->buildErrorSummary($processorNumber, $suite, $process);
         }
 
         $this->totalBuffer[] = new Report(
@@ -260,5 +258,88 @@ class Processes
     public function getReport(): array
     {
         return $this->totalBuffer;
+    }
+
+    private function buildErrorSummary(int $processorNumber, string $suite, Process $process): string
+    {
+        $errorOutput = $process->getErrorOutput();
+        $output = '' !== trim($errorOutput) ? $errorOutput : $process->getOutput();
+
+        return sprintf('%d. (%s)', $processorNumber, $suite).PHP_EOL
+            .$this->extractCompactFailureOutput($output);
+    }
+
+    private function extractCompactFailureOutput(string $output): string
+    {
+        $output = str_replace(["\r\n", "\r"], "\n", $output);
+        $parts = [];
+
+        if (preg_match_all('/(?:^|\n)([ \t]*Failed step:.*?)(?=\n[ \t]*Failed step:|\n[ \t]*--- Failed scenarios:|\z)/s', $output, $matches)) {
+            foreach ($matches[1] as $failedStep) {
+                $parts[] = trim($failedStep);
+            }
+        }
+
+        $failedScenarios = $this->extractFailedScenariosSection($output);
+        if (null !== $failedScenarios) {
+            $parts[] = $failedScenarios;
+        }
+
+        if ([] === $parts) {
+            $parts[] = $this->extractOutputTail($output);
+        }
+
+        return rtrim(implode(PHP_EOL.PHP_EOL, $parts)).PHP_EOL;
+    }
+
+    private function extractFailedScenariosSection(string $output): ?string
+    {
+        $lines = explode("\n", $output);
+
+        foreach ($lines as $index => $line) {
+            if ('--- Failed scenarios:' !== trim($line)) {
+                continue;
+            }
+
+            $section = ['--- Failed scenarios:'];
+            $foundScenario = false;
+
+            for ($lineIndex = $index + 1, $lineCount = count($lines); $lineIndex < $lineCount; ++$lineIndex) {
+                $trimmedLine = trim($lines[$lineIndex]);
+
+                if ('' === $trimmedLine) {
+                    if (!$foundScenario) {
+                        $section[] = '';
+                    }
+                    continue;
+                }
+
+                if (1 === preg_match('/:\d+$/', $trimmedLine)) {
+                    $section[] = $trimmedLine;
+                    $foundScenario = true;
+                    continue;
+                }
+
+                if ($foundScenario) {
+                    break;
+                }
+
+                return null;
+            }
+
+            return $foundScenario ? rtrim(implode(PHP_EOL, $section)) : null;
+        }
+
+        return null;
+    }
+
+    private function extractOutputTail(string $output, int $lineCount = 4): string
+    {
+        $lines = array_values(array_filter(
+            array_map('trim', explode("\n", $output)),
+            static fn (string $line): bool => '' !== $line
+        ));
+
+        return implode(PHP_EOL, array_slice($lines, -$lineCount));
     }
 }

--- a/src/Process/Processes.php
+++ b/src/Process/Processes.php
@@ -235,10 +235,11 @@ class Processes
         $suite = (string) $env[EnvCommandCreator::ENV_TEST_ARGUMENT];
         $number = $env[EnvCommandCreator::ENV_TEST_CHANNEL];
         $numberOnThread = $env[EnvCommandCreator::ENV_TEST_IS_FIRST_ON_CHANNEL];
+        $processorNumber = (int) (string) $number;
 
         if (!$process->isSuccessful()) {
             ++$this->errorCounter;
-            $this->errorBuffer[$suite] = sprintf('[%s] %s', $number, $suite).PHP_EOL;
+            $this->errorBuffer[$suite] = sprintf('[%d] %s', $processorNumber, $suite).PHP_EOL;
             $this->errorBuffer[$suite] .= $process->getOutput();
             $this->errorBuffer[$suite] .= $process->getErrorOutput();
         }
@@ -247,7 +248,7 @@ class Processes
             $suite,
             $process->isSuccessful(),
             microtime(true) - $this->startTimes[$key],
-            (int) $number,
+            $processorNumber,
             isset($this->errorBuffer[$suite]) ? $this->errorBuffer[$suite] : null,
             (bool) $numberOnThread // @todo if EnvCommandCreator::ENV_TEST_IS_FIRST_ON_CHANNEL bool, remove this
         );

--- a/src/Process/Processes.php
+++ b/src/Process/Processes.php
@@ -247,7 +247,7 @@ class Processes
             $suite,
             $process->isSuccessful(),
             microtime(true) - $this->startTimes[$key],
-            $number,
+            (int) $number,
             isset($this->errorBuffer[$suite]) ? $this->errorBuffer[$suite] : null,
             (bool) $numberOnThread // @todo if EnvCommandCreator::ENV_TEST_IS_FIRST_ON_CHANNEL bool, remove this
         );

--- a/src/UI/DotProgressRenderer.php
+++ b/src/UI/DotProgressRenderer.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Liuggio\Fastest\UI;
+
+use Liuggio\Fastest\Process\Processes;
+use Liuggio\Fastest\Queue\QueueInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class DotProgressRenderer implements RendererInterface
+{
+    /**
+     * @var int
+     */
+    private $messageInTheQueue;
+
+    /**
+     * @var bool
+     */
+    private $errorsSummary;
+
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    /**
+     * @var int
+     */
+    private $lastIndex;
+
+    /**
+     * @var int
+     */
+    private $dotsInLine;
+
+    /**
+     * @param int $messageInTheQueue
+     * @param bool $errorsSummary Whether to display errors summary in the footer
+     * @param OutputInterface $output
+     * @param int $dotsInLine
+     */
+    public function __construct(
+        int $messageInTheQueue,
+        bool $errorsSummary,
+        OutputInterface $output,
+        int $dotsInLine = 70
+    ) {
+        $this->messageInTheQueue = $messageInTheQueue;
+        $this->errorsSummary = $errorsSummary;
+        $this->output = $output;
+        $this->lastIndex = 0;
+        $this->dotsInLine = $dotsInLine;
+    }
+
+    public function renderHeader(QueueInterface $queue): void
+    {
+        $this->output->writeln('');
+        $this->output->writeln('');
+    }
+
+    public function renderBody(QueueInterface $queue, Processes $processes): int
+    {
+        $errorCount = $processes->countErrors();
+        $reports = $processes->getReport();
+        $count = count($reports);
+
+        for ($index = $this->lastIndex; $index < $count; ++$index) {
+            $this->output->write($reports[$index]->isSuccessful() ? '.' : '<error>F</error>');
+            $step = $index + 1;
+
+            if (0 === $step % $this->dotsInLine) {
+                $this->output->writeln(' '.$step.'/'.$this->messageInTheQueue);
+            }
+        }
+
+        $this->lastIndex = $count;
+
+        return $errorCount;
+    }
+
+    public function renderFooter(QueueInterface $queue, Processes $processes): void
+    {
+        $this->renderBody($queue, $processes);
+
+        if (0 !== $this->lastIndex % $this->dotsInLine) {
+            $this->output->writeln(' '.$this->lastIndex.'/'.$this->messageInTheQueue);
+        }
+
+        $this->output->writeln('');
+
+        $errorCount = $processes->countErrors();
+        if ($errorCount > 0) {
+            $this->output->writeln(sprintf('     <error>%d</error> failures.', $errorCount));
+            $this->output->writeln('');
+        }
+
+        if ($this->errorsSummary) {
+            $this->output->writeln($processes->getErrorOutput());
+        }
+
+        $out = '    <info>✔</info> You are great!';
+        if (!$processes->isSuccessful()) {
+            $out = '    <error>✘ ehm broken tests...</error>';
+        }
+
+        $this->output->writeln(PHP_EOL.$out);
+    }
+}

--- a/tests/Command/ParallelCommandTest.php
+++ b/tests/Command/ParallelCommandTest.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Liuggio\Fastest\Command;
+
+use Liuggio\Fastest\Queue\QueueInterface;
+use Liuggio\Fastest\UI\DotProgressRenderer;
+use Liuggio\Fastest\UI\NoProgressRenderer;
+use Liuggio\Fastest\UI\ProgressBarRenderer;
+use Liuggio\Fastest\UI\RendererInterface;
+use Liuggio\Fastest\UI\VerboseRenderer;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ParallelCommandTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldUseProgressBarRendererByDefault(): void
+    {
+        $command = new TestableParallelCommand();
+
+        $renderer = $command->renderer(
+            $this->createInput($command),
+            $this->createOutput(),
+            $this->createQueue(),
+            false,
+            false
+        );
+
+        $this->assertInstanceOf(ProgressBarRenderer::class, $renderer);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldUseDotProgressRendererWhenDotProgressIsRequested(): void
+    {
+        $command = new TestableParallelCommand();
+
+        $renderer = $command->renderer(
+            $this->createInput($command),
+            $this->createOutput(),
+            $this->createQueue(),
+            false,
+            true
+        );
+
+        $this->assertInstanceOf(DotProgressRenderer::class, $renderer);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldUseNoProgressRendererBeforeDotProgressRenderer(): void
+    {
+        $command = new TestableParallelCommand();
+
+        $renderer = $command->renderer(
+            $this->createInput($command),
+            $this->createOutput(),
+            $this->createQueue(),
+            true,
+            true
+        );
+
+        $this->assertInstanceOf(NoProgressRenderer::class, $renderer);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldUseVerboseRendererForVerboseOutputWhenDotProgressIsNotRequested(): void
+    {
+        $command = new TestableParallelCommand();
+
+        $renderer = $command->renderer(
+            $this->createInput($command),
+            $this->createOutput(OutputInterface::VERBOSITY_VERBOSE),
+            $this->createQueue(),
+            false,
+            false
+        );
+
+        $this->assertInstanceOf(VerboseRenderer::class, $renderer);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldShowRerunErrorSummaryWhenErrorsSummaryIsEnabled(): void
+    {
+        $command = new TestableParallelCommand();
+
+        $this->assertTrue($command->rerunErrorSummary($this->createInput($command)));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldHideRerunErrorSummaryWhenErrorsSummaryIsDisabled(): void
+    {
+        $command = new TestableParallelCommand();
+
+        $this->assertFalse($command->rerunErrorSummary($this->createInput($command, ['--no-errors-summary' => true])));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldShowRerunErrorSummaryWhenExplicitlyRequested(): void
+    {
+        $command = new TestableParallelCommand();
+
+        $input = $this->createInput($command, [
+            '--no-errors-summary' => true,
+            '--show-rerun-failed' => true,
+        ]);
+
+        $this->assertTrue($command->rerunErrorSummary($input));
+    }
+
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    private function createInput(TestableParallelCommand $command, array $parameters = []): ArrayInput
+    {
+        return new ArrayInput($parameters, $command->getDefinition());
+    }
+
+    private function createOutput(int $verbosity = OutputInterface::VERBOSITY_NORMAL): BufferedOutput
+    {
+        return new BufferedOutput($verbosity, false);
+    }
+
+    private function createQueue(): QueueInterface
+    {
+        $queue = $this->createMock(QueueInterface::class);
+        $queue
+            ->method('count')
+            ->willReturn(3)
+        ;
+
+        return $queue;
+    }
+}
+
+class TestableParallelCommand extends ParallelCommand
+{
+    public function renderer(
+        InputInterface $input,
+        OutputInterface $output,
+        QueueInterface $queue,
+        bool $noProgressOption,
+        bool $dotProgressOption
+    ): RendererInterface {
+        return $this->createRenderer($input, $output, $queue, $noProgressOption, $dotProgressOption);
+    }
+
+    public function rerunErrorSummary(InputInterface $input): bool
+    {
+        return $this->hasRerunErrorSummary($input);
+    }
+}

--- a/tests/Process/ProcessesManagerTest.php
+++ b/tests/Process/ProcessesManagerTest.php
@@ -22,7 +22,7 @@ class ProcessesManagerTest extends TestCase
         $factory->expects($this->once())
             ->method('createAProcessForACustomCommand')
             ->with($this->anything(), $this->equalTo(1), $this->equalTo(1), $this->equalTo(true))
-            ->willReturn(new Process(['echo ', rand()], sys_get_temp_dir()));
+            ->willReturn(new Process(['echo', (string) rand()], sys_get_temp_dir()));
 
         $manager = new ProcessesManager(1, $factory, 'echo "ciao"');
 
@@ -57,7 +57,7 @@ class ProcessesManagerTest extends TestCase
         $factory->expects($this->exactly(1))
             ->method('createAProcess')
             ->with($this->anything(), $this->equalTo(1), $this->equalTo(1), $this->equalTo(true))
-            ->willReturn(new Process(['echo '], (string) rand()));
+            ->willReturn(new Process(['echo'], (string) rand()));
 
         $manager = new ProcessesManager(1, $factory);
 
@@ -106,7 +106,7 @@ class ProcessesManagerTest extends TestCase
             $factory->expects($this->at($at))
                 ->method('createAProcess')
                 ->with($this->anything(), $this->equalTo($expectation[0]), $this->equalTo($expectation[1]), $this->equalTo($expectation[2]))
-                ->willReturn(new Process(['echo '], (string) rand()));
+                ->willReturn(new Process(['echo'], (string) rand()));
         }
 
         $manager = new ProcessesManager(1, $factory);

--- a/tests/Process/ProcessesTest.php
+++ b/tests/Process/ProcessesTest.php
@@ -180,7 +180,7 @@ class ProcessesTest extends TestCase
     /**
      * @test
      */
-    public function shouldPutProcessOutputOnNextLineAfterErrorHeader(): void
+    public function shouldUseProcessErrorOutputForErrorSummary(): void
     {
         $process = $this->createMock(Process::class);
         $process
@@ -198,7 +198,63 @@ class ProcessesTest extends TestCase
             ]);
         $process
             ->method('getOutput')
-            ->willReturn("Failed step: And I do a thing\n");
+            ->willReturn("Feature: noisy full feature output\n");
+        $process
+            ->method('getErrorOutput')
+            ->willReturn(
+                "    And I delete the memcached key 'local://example'\n"
+                ."    When I call POST 'hercules://connect/wallet/open'\n"
+                ."    Then the last response should be status 200\n"
+                ."Failed step: And I do a thing\n"
+                ."    The array 'return' count '0' does not match the expected value: '1'\n"
+                ."    Failed asserting that 0 is identical to 1.\n"
+                ."\n"
+                ."--- Failed scenarios:\n"
+                ."\n"
+                ."features/example.feature:123\n"
+                ."\n"
+                ."1 scenario (1 failed)\n"
+            );
+
+        $processes = new Processes([$process]);
+        $processes->start(0);
+
+        $processes->cleanUP();
+
+        $this->assertSame(
+            "1. (features/example.feature:123)\nFailed step: And I do a thing\n"
+            ."    The array 'return' count '0' does not match the expected value: '1'\n"
+            ."    Failed asserting that 0 is identical to 1.\n"
+            ."\n"
+            ."--- Failed scenarios:\n"
+            ."\n"
+            ."features/example.feature:123\n",
+            $processes->getErrorOutput()['features/example.feature:123']
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function shouldUseProcessOutputForErrorSummaryWhenErrorOutputIsEmpty(): void
+    {
+        $process = $this->createMock(Process::class);
+        $process
+            ->method('isTerminated')
+            ->willReturn(true);
+        $process
+            ->method('isSuccessful')
+            ->willReturn(false);
+        $process
+            ->method('getEnv')
+            ->willReturn([
+                EnvCommandCreator::ENV_TEST_ARGUMENT => 'tests/ExampleTest.php',
+                EnvCommandCreator::ENV_TEST_CHANNEL => 2,
+                EnvCommandCreator::ENV_TEST_IS_FIRST_ON_CHANNEL => true,
+            ]);
+        $process
+            ->method('getOutput')
+            ->willReturn("There was 1 failure:\n");
         $process
             ->method('getErrorOutput')
             ->willReturn('');
@@ -209,8 +265,8 @@ class ProcessesTest extends TestCase
         $processes->cleanUP();
 
         $this->assertSame(
-            "[1] features/example.feature:123\nFailed step: And I do a thing\n",
-            $processes->getErrorOutput()['features/example.feature:123']
+            "2. (tests/ExampleTest.php)\nThere was 1 failure:\n",
+            $processes->getErrorOutput()['tests/ExampleTest.php']
         );
     }
 

--- a/tests/Process/ProcessesTest.php
+++ b/tests/Process/ProcessesTest.php
@@ -178,6 +178,43 @@ class ProcessesTest extends TestCase
     }
 
     /**
+     * @test
+     */
+    public function shouldPutProcessOutputOnNextLineAfterErrorHeader(): void
+    {
+        $process = $this->createMock(Process::class);
+        $process
+            ->method('isTerminated')
+            ->willReturn(true);
+        $process
+            ->method('isSuccessful')
+            ->willReturn(false);
+        $process
+            ->method('getEnv')
+            ->willReturn([
+                EnvCommandCreator::ENV_TEST_ARGUMENT => 'features/example.feature:123',
+                EnvCommandCreator::ENV_TEST_CHANNEL => 1,
+                EnvCommandCreator::ENV_TEST_IS_FIRST_ON_CHANNEL => true,
+            ]);
+        $process
+            ->method('getOutput')
+            ->willReturn("Failed step: And I do a thing\n");
+        $process
+            ->method('getErrorOutput')
+            ->willReturn('');
+
+        $processes = new Processes([$process]);
+        $processes->start(0);
+
+        $processes->cleanUP();
+
+        $this->assertSame(
+            "[1] features/example.feature:123\nFailed step: And I do a thing\n",
+            $processes->getErrorOutput()['features/example.feature:123']
+        );
+    }
+
+    /**
      * @param string $method
      *
      * @return MockObject|Process

--- a/tests/UI/DotProgressRendererTest.php
+++ b/tests/UI/DotProgressRendererTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Liuggio\Fastest\UI;
+
+use Liuggio\Fastest\Process\Processes;
+use Liuggio\Fastest\Process\Report;
+use Liuggio\Fastest\Queue\QueueInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class DotProgressRendererTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldRenderADotForSuccessfulReportsAndAnFForFailedReports(): void
+    {
+        $output = new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, false);
+        $renderer = new DotProgressRenderer(3, false, $output);
+        $processes = $this->createProcesses([
+            $this->createReport(true),
+            $this->createReport(true),
+            $this->createReport(false),
+        ], 1, [], false);
+
+        $renderer->renderHeader($this->createQueue());
+        $renderer->renderBody($this->createQueue(), $processes);
+        $renderer->renderFooter($this->createQueue(), $processes);
+
+        $renderedOutput = $output->fetch();
+        $this->assertStringContainsString('..F 3/3', $renderedOutput);
+        $this->assertStringContainsString('1 failures.', $renderedOutput);
+        $this->assertStringContainsString('ehm broken tests', $renderedOutput);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldRenderProgressCountEveryConfiguredNumberOfDots(): void
+    {
+        $output = new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, false);
+        $renderer = new DotProgressRenderer(3, false, $output, 2);
+        $processes = $this->createProcesses([
+            $this->createReport(true),
+            $this->createReport(true),
+            $this->createReport(true),
+        ]);
+
+        $renderer->renderHeader($this->createQueue());
+        $renderer->renderFooter($this->createQueue(), $processes);
+
+        $renderedOutput = $output->fetch();
+        $this->assertStringContainsString('.. 2/3', $renderedOutput);
+        $this->assertStringContainsString('. 3/3', $renderedOutput);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldRenderErrorSummaryWhenEnabled(): void
+    {
+        $output = new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, false);
+        $renderer = new DotProgressRenderer(1, true, $output);
+        $processes = $this->createProcesses(
+            [$this->createReport(false)],
+            1,
+            ['suite' => "Failed step: And I do a thing\n--- Failed scenarios:\npath/to/my.feature:123\n"],
+            false
+        );
+
+        $renderer->renderFooter($this->createQueue(), $processes);
+
+        $renderedOutput = $output->fetch();
+        $this->assertStringContainsString('Failed step: And I do a thing', $renderedOutput);
+        $this->assertStringContainsString('path/to/my.feature:123', $renderedOutput);
+    }
+
+    /**
+     * @param Report[] $reports
+     * @param array<string, string> $errorOutput
+     */
+    private function createProcesses(
+        array $reports,
+        int $errorCount = 0,
+        array $errorOutput = [],
+        bool $successful = true
+    ): Processes {
+        $processes = $this->getMockBuilder(Processes::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $processes
+            ->method('getReport')
+            ->willReturn($reports)
+        ;
+        $processes
+            ->method('countErrors')
+            ->willReturn($errorCount)
+        ;
+        $processes
+            ->method('getErrorOutput')
+            ->willReturn($errorOutput)
+        ;
+        $processes
+            ->method('isSuccessful')
+            ->willReturn($successful)
+        ;
+
+        return $processes;
+    }
+
+    private function createReport(bool $successful): Report
+    {
+        return new Report('suite', $successful, 0.1, 1, null, false);
+    }
+
+    private function createQueue(): QueueInterface
+    {
+        return $this->createMock(QueueInterface::class);
+    }
+}


### PR DESCRIPTION
Ability to use dot/progress output instead of progress bar and a matching step and feature summary of any failures after a re-run - matching the experience of using behat with format=progress

  Progress behavior is now:

  - default remains the existing Symfony progress bar
  - --dot-progress option to use dots/progress format
  - --no-progress still wins in the upstream branch if combined
  - --show-rerun-failed makes rerun failures print even with --no-errors-summary
